### PR TITLE
Update geometry with sept2025 intervention insight and more

### DIFF
--- a/generator/fieldcage.py
+++ b/generator/fieldcage.py
@@ -724,7 +724,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
     resistorAssembly = g4.AssemblyVolume(name="resistorAssembly", registry=reg)
     resistorShielding_PV = g4.PhysicalVolume(
-        name="resistorShielding_PV",
+        name="resistorShielding",
         rotation=[0, 0, 0],
         position=[0, 0, 0],
         logicalVolume=resistorShielding_LV,
@@ -732,7 +732,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     resistor_PV = g4.PhysicalVolume(
-        name="resistor_PV",
+        name="resistor",
         rotation=[0, 0, 0],
         position=[-resistorShieldingLength/2 + resistorDistanceToShieldingSlotEdge + resistorLength/2, resistorShieldingSlotWidthShift - resistorShieldingSlotWidth/2 + resistorWidth/2, 0],
         logicalVolume=resistor_LV,
@@ -791,7 +791,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
 
     if cathode_type == "plain":
         cathodeFoilKapton_PV = g4.PhysicalVolume(
-            name="cathodeFoilKapton_PV",
+            name="cathodeFoilKapton",
             rotation=[0, 0, 0],
             position=[0, 0, 0],
             logicalVolume=cathodeFoilKapton_LV,
@@ -800,7 +800,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         )
             
         cathodeFoilCuLeft_PV = g4.PhysicalVolume(
-            name="cathodeFoilCuLeft_PV",
+            name="cathodeFoilCuLeft",
             rotation=[0, 0, 0],
             position=[0, 0, cathodeKaptonThickness/2],
             logicalVolume=cathodeFoilCu_LV,
@@ -808,7 +808,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
             registry=reg
         )
         cathodeFoilCuRight_PV = g4.PhysicalVolume(
-            name="cathodeFoilCuRight_PV",
+            name="cathodeFoilCuRight",
             rotation=[0, 0, 0],
             position=[0, 0, -cathodeKaptonThickness/2],
             logicalVolume=cathodeFoilCu_LV,
@@ -822,7 +822,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
             wire_position_XorY = cathodeLength/2 - first_wire_distance_to_frame - i * cathodeDistanceBetweenWires
 
             g4.PhysicalVolume(
-                name=f"cathodeWireX{i+1}_PV",
+                name=f"cathodeWireX{i+1}",
                 rotation=[90*np.pi/180, 0, 0],
                 position = [wire_position_XorY, 0, -z_shift],
                 logicalVolume=cathodeSingleWire_LV,
@@ -830,7 +830,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
                 registry=reg
             )
             g4.PhysicalVolume(
-                name=f"cathodeWireY{i+1}_PV",
+                name=f"cathodeWireY{i+1}",
                 rotation=[0, 90*np.pi/180, 0],
                 position = [0, wire_position_XorY, z_shift],
                 logicalVolume=cathodeSingleWire_LV,
@@ -841,7 +841,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         raise ValueError("Invalid cathode type. Choose either 'plain' or 'wired'.")
 
     cathodeFrame_PV = g4.PhysicalVolume(
-        name="cathodeFrame_PV",
+        name="cathodeFrame",
         rotation=[0, 0, 0],
         position=[0, 0, 0],
         logicalVolume=cathodeFrame_LV,
@@ -850,7 +850,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
     
     cathodeSideFrameLeft_PV = g4.PhysicalVolume(
-        name="cathodeSideFrameLeft_PV",
+        name="cathodeSideFrameLeft",
         rotation=[0, 0, 0],
         position=[0, 0, +(sideSeparatorThickness/2 + cathodeSideFrameThickness/2)],
         logicalVolume=cathodeSideFrame_LV,
@@ -858,7 +858,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     cathodeSideFrameRight_PV = g4.PhysicalVolume(
-        name="cathodeSideFrameRight_PV",
+        name="cathodeSideFrameRight",
         rotation=[0, 0, 0],
         position=[0, 0, -(sideSeparatorThickness/2 + cathodeSideFrameThickness/2)],
         logicalVolume=cathodeSideFrame_LV,
@@ -866,7 +866,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     sideSeparator_PV = g4.PhysicalVolume(
-        name="sideSeparator_PV",
+        name="sideSeparator",
         rotation=[0, 0, 0],
         position=[0, 0, 0],
         logicalVolume=sideSeparator_LV,
@@ -875,7 +875,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
     
     cathodeFeedthrough_PV = g4.PhysicalVolume(
-        name="cathodeFeedthrough_PV",
+        name="cathodeFeedthrough",
         rotation=[0, 0, 0],
         position=[-(cathodeSideFrameLength/2 - cathodeFeedThroughWidth/2), 0, 0],
         logicalVolume=cathodeFeedthrough_LV,
@@ -884,7 +884,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
     
     cornersLeft_PV = g4.PhysicalVolume(
-        name="cornersLeft_PV",
+        name="cornersLeft",
         rotation=[0, 0, 0],
         position=[0, 0, +(sideSeparatorThickness/2 + cathodeSideFrameThickness + cornersThickness/2)],
         logicalVolume=corners_LV,
@@ -892,7 +892,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     cornersRight_PV = g4.PhysicalVolume(
-        name="cornersRight_PV",
+        name="cornersRight",
         rotation=[0, 0, 0],
         position=[0, 0, -(sideSeparatorThickness/2 + cathodeSideFrameThickness + cornersThickness/2)],
         logicalVolume=corners_LV,
@@ -900,7 +900,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     closerFrameLeft_PV = g4.PhysicalVolume(
-        name="closerFrameLeft_PV",
+        name="closerFrameLeft",
         rotation=[0, 0, 0],
         position=[0, 0, +(sideSeparatorThickness/2 + cathodeSideFrameThickness + cornersThickness + closerFrameThickness/2)],
         logicalVolume=closerFrame_LV,
@@ -908,7 +908,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     closerFrameRight_PV = g4.PhysicalVolume(
-        name="closerFrameRight_PV",
+        name="closerFrameRight",
         rotation=[0, 0, 0],
         position=[0, 0, -(sideSeparatorThickness/2 + cathodeSideFrameThickness + cornersThickness + closerFrameThickness/2)],
         logicalVolume=closerFrame_LV,
@@ -917,7 +917,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
     
     ringsBoardLeft_PV = g4.PhysicalVolume(
-        name="ringsBoardLeft_PV",
+        name="ringsBoardLeft",
         rotation=[0, 0, 0],
         position=[0, 0, +(sideSeparatorThickness/2 + cathodeSideFrameThickness + ringsBoardThickness/2)],
         logicalVolume=ringsBoard_LV,
@@ -925,7 +925,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     ringsBoardRight_PV = g4.PhysicalVolume(
-        name="ringsBoardRight_PV",
+        name="ringsBoardRight",
         rotation=[0, 0, 0],
         position=[0, 0, -(sideSeparatorThickness/2 + cathodeSideFrameThickness + ringsBoardThickness/2)],
         logicalVolume=ringsBoard_LV,
@@ -936,7 +936,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     for i in range(ringNumber):
         distance = (ringSeparation + ringThickness) * i # to the beginning of the board
         g4.PhysicalVolume(
-            name=f"ringLeft{i+1}_PV",
+            name=f"ringLeft{i+1}",
             rotation=[0, 0, 0],
             position=[0, 0, +(sideSeparatorThickness/2 + cathodeSideFrameThickness + ringThickness/2 + distance)],
             logicalVolume=ring_LV,
@@ -944,7 +944,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
             registry=reg
         )
         g4.PhysicalVolume(
-            name=f"ringRight{i+1}_PV",
+            name=f"ringRight{i+1}",
             rotation=[0, 0, 0],
             position=[0, 0, -(sideSeparatorThickness/2 + cathodeSideFrameThickness + ringThickness/2 + distance)],
             logicalVolume=ring_LV,
@@ -954,7 +954,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
 
 
     supportCorners_PV = g4.PhysicalVolume(
-        name="supportCorners_PV",
+        name="supportCorners",
         rotation=[0, 0, 0],
         position=[0, 0, 0],
         logicalVolume=supportCorners_LV,
@@ -963,7 +963,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
 
     supportColumn1_PV = g4.PhysicalVolume(
-        name="supportColumn1_PV",
+        name="supportColumn1",
         rotation=[0, 0, 0],
         position=[-(sideSeparatorLength/2 + supportColumnWidth/2), supportColumnHeightShift, 0],
         logicalVolume=supportColumn_LV,
@@ -971,7 +971,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     supportColumn2_PV = g4.PhysicalVolume(
-        name="supportColumn2_PV",
+        name="supportColumn2",
         rotation=[0, 0, 0],
         position=[sideSeparatorLength/2 + supportColumnWidth/2, supportColumnHeightShift, 0],
         logicalVolume=supportColumn_LV,
@@ -979,7 +979,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     supportBottomBeam_PV = g4.PhysicalVolume(
-        name="supportBeam_PV",
+        name="supportBeam",
         rotation=[0, 0, 0],
         position=[0, -(cathodeSideFrameLength/2 + supportBeamWidth/2), 0],
         logicalVolume=supportBeam_LV,
@@ -987,7 +987,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     supportTopBeam_PV = g4.PhysicalVolume(
-        name="supportTopBeam_PV",
+        name="supportTopBeam",
         rotation=[0, 0, 0],
         position=[0, sideSeparatorLength/2+supportBeamWidth/2, 0],
         logicalVolume=supportBeam_LV,
@@ -996,7 +996,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
 
     supportTopSideBeamLeft_PV = g4.PhysicalVolume(
-        name="supportTopSideBeamLeft_PV",
+        name="supportTopSideBeamLeft",
         rotation=[0, 0, 0],
         position=[-cornersSlotHeight/2+supportTopSideBeamLength/2, cornersLength/2+supportTopSideBeamWidth/2, sideSeparatorThickness/2 + cathodeSideFrameThickness + supportTopSideBeamThickness/2],
         logicalVolume=supportTopSideBeam_LV,
@@ -1004,7 +1004,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     supportTopSideBeamRight_PV = g4.PhysicalVolume(
-        name="supportTopSideBeamRight_PV",
+        name="supportTopSideBeamRight",
         rotation=[0, np.pi, 0],
         position=[-(-cornersSlotHeight/2+supportTopSideBeamLength/2), cornersLength/2+supportTopSideBeamWidth/2, -(sideSeparatorThickness/2 + cathodeSideFrameThickness + supportTopSideBeamThickness/2)],
         logicalVolume=supportTopSideBeam_LV,
@@ -1013,7 +1013,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
 
     supportToVessel1_PV = g4.PhysicalVolume(
-        name="supportToVessel1_PV",
+        name="supportToVessel1",
         rotation=[0, 0, 0],
         position=[-(supportToVesselDistanceBetweenThem/2+supportToVesselLength/2), -(supportCornersLength/2+supportToVesselHeight/2), 0],
         logicalVolume=supportToVessel_LV,
@@ -1021,7 +1021,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
         registry=reg
     )
     supportToVessel2_PV = g4.PhysicalVolume(
-        name="supportToVessel2_PV",
+        name="supportToVessel2",
         rotation=[0, np.pi, 0],
         position=[supportToVesselDistanceBetweenThem/2+supportToVesselLength/2, -(supportCornersLength/2+supportToVesselHeight/2), 0],
         logicalVolume=supportToVessel_LV,
@@ -1030,7 +1030,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
 
     handle_PV = g4.PhysicalVolume(
-        name="handle_PV",
+        name="handle",
         rotation=[0, 0, 0],
         position=[-(cornersInnerLength/2 + supportColumnWidth + handleWidth/2), 0, 0],
         logicalVolume=handle_LV,
@@ -1040,7 +1040,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
 
     """ # The vacuum cylinder will not be used in the field cage assembly for now
     vacuumCylinder_PV = g4.PhysicalVolume(
-        name="vacuumCylinder_PV",
+        name="vacuumCylinder",
         rotation=[np.pi/2, 0, 0],
         position=[0, cornersLength/2 + supportTopSideBeamWidth + vacuumCylinderLength/2, 0],
         logicalVolume=vacuumCylinder_LV,
@@ -1050,7 +1050,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     """
 
     resistorAssemblyLeft_PV = g4.PhysicalVolume(
-        name="resistorAssemblyLeft_PV",
+        name="resistorAssemblyLeft",
         rotation=[0, 0, 0],
         position=[(cornersSlotHeight/2-resistorShieldingLength/2), cornersInnerLength/2+resistorShieldingWidth/2, (sideSeparatorThickness/2 + cathodeSideFrameThickness + resistorShieldingThickness/2)],
         logicalVolume=resistorAssembly,
@@ -1059,7 +1059,7 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
 
     resistorAssemblyRight_PV = g4.PhysicalVolume(
-        name="resistorAssemblyRight_PV",
+        name="resistorAssemblyRight",
         rotation=[0, np.pi, 0],
         position=[-(cornersSlotHeight/2-resistorShieldingLength/2), cornersInnerLength/2+resistorShieldingWidth/2, -(sideSeparatorThickness/2 + cathodeSideFrameThickness + resistorShieldingThickness/2)],
         logicalVolume=resistorAssembly,

--- a/generator/fieldcage.py
+++ b/generator/fieldcage.py
@@ -952,23 +952,6 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
             registry=reg
         )
 
-    resistorAssemblyLeft_PV = g4.PhysicalVolume(
-        name="resistorAssemblyLeft_PV",
-        rotation=[0, 0, 0],
-        position=[(cornersSlotHeight/2-resistorShieldingLength/2), cornersInnerLength/2+resistorShieldingWidth/2, (sideSeparatorThickness/2 + cathodeSideFrameThickness + resistorShieldingThickness/2)],
-        logicalVolume=resistorAssembly,
-        motherVolume=fieldcage_assembly,
-        registry=reg
-    )
-
-    resistorAssemblyRight_PV = g4.PhysicalVolume(
-        name="resistorAssemblyRight_PV",
-        rotation=[0, np.pi, 0],
-        position=[-(cornersSlotHeight/2-resistorShieldingLength/2), cornersInnerLength/2+resistorShieldingWidth/2, -(sideSeparatorThickness/2 + cathodeSideFrameThickness + resistorShieldingThickness/2)],
-        logicalVolume=resistorAssembly,
-        motherVolume=fieldcage_assembly,
-        registry=reg
-    )
 
     supportCorners_PV = g4.PhysicalVolume(
         name="supportCorners_PV",
@@ -1066,6 +1049,23 @@ def generate_fieldcage_assembly(name="fieldcage_assembly", registry=None, cathod
     )
     """
 
+    resistorAssemblyLeft_PV = g4.PhysicalVolume(
+        name="resistorAssemblyLeft_PV",
+        rotation=[0, 0, 0],
+        position=[(cornersSlotHeight/2-resistorShieldingLength/2), cornersInnerLength/2+resistorShieldingWidth/2, (sideSeparatorThickness/2 + cathodeSideFrameThickness + resistorShieldingThickness/2)],
+        logicalVolume=resistorAssembly,
+        motherVolume=fieldcage_assembly,
+        registry=reg
+    )
+
+    resistorAssemblyRight_PV = g4.PhysicalVolume(
+        name="resistorAssemblyRight_PV",
+        rotation=[0, np.pi, 0],
+        position=[-(cornersSlotHeight/2-resistorShieldingLength/2), cornersInnerLength/2+resistorShieldingWidth/2, -(sideSeparatorThickness/2 + cathodeSideFrameThickness + resistorShieldingThickness/2)],
+        logicalVolume=resistorAssembly,
+        motherVolume=fieldcage_assembly,
+        registry=reg
+    )
     return reg
 
 

--- a/generator/gem.py
+++ b/generator/gem.py
@@ -27,7 +27,8 @@ gemFrameFeedthroughIndentationDepth = 0.5 # mm
 
 gemmMSeparatorLength = 242.5 # mm
 gemmMSeparatorWidth = 16.0 # mm
-gemmMSeparatorThickness = 5.5 # mm. There is a protusion to tense the GEM foil that is 2mm more. This is not taken into account...
+# gemmMSeparatorThickness establish the distance between the GEM and the micromegas (forgetting about the mM thickness)
+gemmMSeparatorThickness = 6.5 # mm. Measured (in sept2025 intervention) distance between GEM frame and micromegas board = 10.5mm, minus 4mm frame thickness = 6.5mm
 gemmMSeparatorExtensionLength = 16.0 # mm
 gemmMSeparatorExtensionWidth = 10.0 # mm
 gemmMSeparatorExtensionDistance = 128.0 # mm, this is the distance from the closer edges of the extensions

--- a/generator/gem.py
+++ b/generator/gem.py
@@ -382,9 +382,9 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
         registry=reg
     )
 
-    separator1_pos = np.array([ 0, gemmMSeparatorDistance/2 + gemmMSeparatorWidth/2, -side_z_dir*(gemmMSeparatorThickness/2+gemKaptonFoilThickness)])
+    separator1_pos = np.array([ 0, gemmMSeparatorDistance/2 + gemmMSeparatorWidth/2, -side_z_dir*(gemmMSeparatorThickness/2+gemKaptonFoilThickness/2)])
     fixer_wrt_separator1_pos = np.array([ 0, gemmMSeparatorFixerToSeparatorDistance + gemmMSeparatorWidth/2 + gemmMSeparatorFixerWidth/2, side_z_dir*(gemmMSeparatorThickness/2 + gemmMSeparatorFixerThickness/2)])
-    separator2_pos = np.array([ 0, -(gemmMSeparatorDistance/2 + gemmMSeparatorWidth/2), -side_z_dir*(gemmMSeparatorThickness/2+gemKaptonFoilThickness)])
+    separator2_pos = np.array([ 0, -(gemmMSeparatorDistance/2 + gemmMSeparatorWidth/2), -side_z_dir*(gemmMSeparatorThickness/2+gemKaptonFoilThickness/2)])
     fixer_wrt_separator2_pos = np.array([ 0, -(gemmMSeparatorFixerToSeparatorDistance + gemmMSeparatorWidth/2 + gemmMSeparatorFixerWidth/2), side_z_dir*(gemmMSeparatorThickness/2 + gemmMSeparatorFixerThickness/2)])
     
     gemmMSeparator1_PV = g4.PhysicalVolume(

--- a/generator/gem.py
+++ b/generator/gem.py
@@ -350,7 +350,7 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
     side_z_dir = 1 if is_right_side else -1
 
     gemKaptonFoil_PV = g4.PhysicalVolume(
-        name="gemKaptonFoil_PV",
+        name="gemKaptonFoil",
         rotation=[0, 0, 0],
         position=[0, 0, 0],
         logicalVolume=gemKaptonFoil_LV,
@@ -358,7 +358,7 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
         registry=reg
     )
     gemTop_PV = g4.PhysicalVolume(
-        name="gemTop_PV",
+        name="gemTop",
         rotation=[0, 0, 0],
         position=[0, 0, side_z_dir*(gemCopperFoilThickness/2 + gemKaptonFoilThickness/2)],
         logicalVolume=gemTop_LV,
@@ -366,7 +366,7 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
         registry=reg
     )
     gemBottom_PV = g4.PhysicalVolume(
-        name="gemBottom_PV",
+        name="gemBottom",
         rotation=[0, 0, 0],
         position=[0, 0, -side_z_dir*(gemCopperFoilThickness/2 + gemKaptonFoilThickness/2)],
         logicalVolume=gemBottom_LV,
@@ -374,7 +374,7 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
         registry=reg
     )
     gemFrame_PV = g4.PhysicalVolume(
-        name="gemFrame_PV",
+        name="gemFrame",
         rotation=[0, 0, 0],
         position=[0, 0, side_z_dir*(gemKaptonFoilThickness + gemFrameThickness/2)],
         logicalVolume=gemFrame_LV,
@@ -388,7 +388,7 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
     fixer_wrt_separator2_pos = np.array([ 0, -(gemmMSeparatorFixerToSeparatorDistance + gemmMSeparatorWidth/2 + gemmMSeparatorFixerWidth/2), side_z_dir*(gemmMSeparatorThickness/2 + gemmMSeparatorFixerThickness/2)])
     
     gemmMSeparator1_PV = g4.PhysicalVolume(
-        name="gemmMSeparator1_PV",
+        name="gemmMSeparator1",
         rotation=[0, 0, 0],
         position=separator1_pos,
         logicalVolume=gemmMSeparator_LV,
@@ -397,7 +397,7 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
     )
 
     gemmMSeparatorFixer1_PV = g4.PhysicalVolume(
-        name="gemmMSeparatorFixer1_PV",
+        name="gemmMSeparatorFixer1",
         rotation=[0, 0, 0],
         position=separator1_pos + fixer_wrt_separator1_pos,
         logicalVolume=gemmMSeparatorFixer_LV,
@@ -407,7 +407,7 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
 
     # Add the second separator and fixer
     gemmMSeparator2_PV = g4.PhysicalVolume(
-        name="gemmMSeparator2_PV",
+        name="gemmMSeparator2",
         rotation=[0, 0, np.pi],
         position=separator2_pos,
         logicalVolume=gemmMSeparator_LV,
@@ -415,7 +415,7 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
         registry=reg
     )
     gemmMSeparatorFixer2_PV = g4.PhysicalVolume(
-        name="gemmMSeparatorFixer2_PV",
+        name="gemmMSeparatorFixer2",
         rotation=[0, 0, 0],
         position=separator2_pos + fixer_wrt_separator2_pos,
         logicalVolume=gemmMSeparatorFixer_LV,

--- a/generator/gem.py
+++ b/generator/gem.py
@@ -207,7 +207,7 @@ def generate_gem_assembly(name="gem_assembly", registry=None, is_right_side=True
         name="gemFrameInnerSquare",
         pX=gemFrameLength - 2*gemFrameWidth,
         pY=gemFrameLength - 2*gemFrameWidth,
-        pZ=gemFrameThickness,
+        pZ=gemFrameThickness + 0.1, # 0.1 to avoid precision issues
         lunit="mm",
         registry=reg
     )

--- a/generator/micromegas.py
+++ b/generator/micromegas.py
@@ -44,7 +44,7 @@ capSupportColumnThicknessB = 12
 capSupportColumnThicknessC = capSupportColumnLengthC # mm. this is a diameter in reality
 
 capSupportColumnProtrusionAtoB = 2.5 # mm
-capSupportColumnBtoBase = -1 # mm. In the CAD it is -1 mm, but it is adjustable in real life. Negative means that the column B starts below the base, positive means that it starts above the base.
+capSupportColumnBtoBase = -2 # mm. In the CAD it is -1 mm, but it is adjustable in real life. Negative means that the column B starts below the base, positive means that it starts above the base.
 
 capSupportColumnCtoTriangularSupport = 5.45 + 5.05 # mm. 5.05mm should be the columnCradius (6mm) but the hole of the triangular support is smaller (5.05mm radius) in the CAD
 

--- a/generator/micromegas.py
+++ b/generator/micromegas.py
@@ -889,7 +889,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBase_PV = g4.PhysicalVolume(
         rotation=side_rot.tolist(),
         position=[0, 0, 0],
-        name="mMBase_PV",
+        name="mMBase",
         logicalVolume=mMBase_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -900,7 +900,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMTeflonSpacerPad1_PV = g4.PhysicalVolume(
         rotation=[0, 0, 0],
         position=[0, teflonspacerpad_pos_xory, side_z_dir*teflonspacerpad_pos_z],
-        name="mMTeflonSpacerPad1_PV",
+        name="mMTeflonSpacerPad1",
         logicalVolume=mMTeflonSpacerPad_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -908,7 +908,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMTeflonSpacerPad2_PV = g4.PhysicalVolume(
         rotation=[0, 0, 0],
         position=[0, -teflonspacerpad_pos_xory, side_z_dir*teflonspacerpad_pos_z],
-        name="mMTeflonSpacerPad2_PV",
+        name="mMTeflonSpacerPad2",
         logicalVolume=mMTeflonSpacerPad_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -916,7 +916,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMTeflonSpacerPad3_PV = g4.PhysicalVolume(
         rotation=[0, 0, 90*np.pi/180],
         position=[teflonspacerpad_pos_xory, 0, side_z_dir*teflonspacerpad_pos_z],
-        name="mMTeflonSpacerPad3_PV",
+        name="mMTeflonSpacerPad3",
         logicalVolume=mMTeflonSpacerPad_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -924,7 +924,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMTeflonSpacerPad4_PV = g4.PhysicalVolume(
         rotation=[0, 0, 90*np.pi/180],
         position=[-teflonspacerpad_pos_xory, 0, side_z_dir*teflonspacerpad_pos_z],
-        name="mMTeflonSpacerPad4_PV",
+        name="mMTeflonSpacerPad4",
         logicalVolume=mMTeflonSpacerPad_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -936,7 +936,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBaseClosingBracket1_PV = g4.PhysicalVolume(
         rotation=[0, 0, 0],
         position=[0, closingbracket_pos_xory, side_z_dir*closingbracket_pos_z],
-        name="mMBaseClosingBracket1_PV",
+        name="mMBaseClosingBracket1",
         logicalVolume=mMBaseClosingBracket_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -944,7 +944,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBaseClosingBracket2_PV = g4.PhysicalVolume(
         rotation=[0, 0, 0],
         position=[0, -closingbracket_pos_xory, side_z_dir*closingbracket_pos_z],
-        name="mMBaseClosingBracket2_PV",
+        name="mMBaseClosingBracket2",
         logicalVolume=mMBaseClosingBracket_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -952,7 +952,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBaseClosingBracket_3_PV = g4.PhysicalVolume(
         rotation=[0, 0, 90*np.pi/180],
         position=[closingbracket_pos_xory, 0, side_z_dir*closingbracket_pos_z],
-        name="mMBaseClosingBracket3_PV",
+        name="mMBaseClosingBracket3",
         logicalVolume=mMBaseClosingBracket_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -960,7 +960,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBaseClosingBracket_4_PV = g4.PhysicalVolume(
         rotation=[0, 0, 90*np.pi/180],
         position=[-closingbracket_pos_xory, 0, side_z_dir*closingbracket_pos_z],
-        name="mMBaseClosingBracket4_PV",
+        name="mMBaseClosingBracket4",
         logicalVolume=mMBaseClosingBracket_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -969,7 +969,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBaseTeflonRoller1_PV = g4.PhysicalVolume(
         rotation=(np.array([90*3.1416/180, 0, 0]) + side_rot).tolist(),
         position=[-mMBaseLength/2, 0, side_z_dir*(mMBaseThickness/2 + rollerCutShift)],
-        name="mMBaseTeflonRoller1_PV",
+        name="mMBaseTeflonRoller1",
         logicalVolume=roller_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -977,7 +977,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBaseTeflonRoller2_PV = g4.PhysicalVolume(
         rotation=(np.array([-90*3.1416/180, 0, np.pi]) + side_rot).tolist(),
         position=[mMBaseLength/2, 0, side_z_dir*(mMBaseThickness/2 + rollerCutShift)],
-        name="mMBaseTeflonRoller2_PV",
+        name="mMBaseTeflonRoller2",
         logicalVolume=roller_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -990,7 +990,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         mMSupport1_PV = g4.PhysicalVolume(
             rotation=(np.array([0, 0, side_z_dir*45*np.pi/180]) + side_rot).tolist(),  # 45 degrees rotation
             position=[-side_z_dir*mMSupportDistanceToCenter_XorY, side_z_dir*mMSupportDistanceToCenter_XorY, side_z_dir*mMSupport_pos_z],
-            name="mMSupport1_PV",
+            name="mMSupport1",
             logicalVolume=mMSupport_LV,
             motherVolume=micromegas_assembly,
             registry=reg
@@ -998,7 +998,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         mMSupport2_PV = g4.PhysicalVolume(
             rotation=(np.array([0, 0, -side_z_dir*135*np.pi/180]) + side_rot).tolist(),  # 45 degrees rotation
             position=[side_z_dir*mMSupportDistanceToCenter_XorY, -side_z_dir*mMSupportDistanceToCenter_XorY, side_z_dir*mMSupport_pos_z],
-            name="mMSupport2_PV",
+            name="mMSupport2",
             logicalVolume=mMSupport_LV,
             motherVolume=micromegas_assembly,
             registry=reg
@@ -1008,7 +1008,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMCopperFoilLayer2_PV = g4.PhysicalVolume(
         rotation=[0, 0, 0],
         position=[0, 0, mMBoardThickness/2 - mMKaptonFoilThickness - mMCopperFoilThickness -mMKaptonFoilThickness - mMCopperFoilThickness/2],
-        name="mMCopperFoilLayer2_PV",
+        name="mMCopperFoilLayer2",
         logicalVolume=mMCopperFoil_LV,
         motherVolume=mMBoardKapton_LV,
         registry=reg
@@ -1016,7 +1016,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMCopperFoilLayer3_PV = g4.PhysicalVolume(
         rotation=[0, 0, 0],
         position=[0, 0, mMBoardThickness/2 - mMKaptonFoilThickness - mMCopperFoilThickness*2 - mMKaptonFoilThickness*2 - mMCopperFoilThickness/2],
-        name="mMCopperFoilLayer3_PV",
+        name="mMCopperFoilLayer3",
         logicalVolume=mMCopperFoil_LV,
         motherVolume=mMBoardKapton_LV,
         registry=reg
@@ -1025,7 +1025,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBoardKapton_PV = g4.PhysicalVolume(
         rotation=[0, 0, 0],
         position=[0, 0, 0],
-        name="mMBoardKapton_PV",
+        name="mMBoardKapton",
         logicalVolume=mMBoardKapton_LV,
         motherVolume=mMBoardCopper_LV,
         registry=reg
@@ -1034,7 +1034,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBoardCopper_PV = g4.PhysicalVolume(
         rotation=side_rot.tolist(),
         position=[0, 0, -side_z_dir*(mMBaseThickness/2 + mMBoardThickness/2)],
-        name="mMBoardCopper_PV",
+        name="mMBoardCopper",
         logicalVolume=mMBoardCopper_LV,
         motherVolume=micromegas_assembly,
         registry=reg
@@ -1044,7 +1044,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         limandeInnerA_PV = g4.PhysicalVolume(
             rotation=[0, 0, 0],
             position=[0, 0, 0],
-            name="limandeInnerA_PV",
+            name="limandeInnerA",
             logicalVolume=limandeInnerA_LV,
             motherVolume=limandeA_LV,
             registry=reg
@@ -1052,7 +1052,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         limandeInnerB_PV = g4.PhysicalVolume(
             rotation=[0, 0, 0],
             position=[0, 0, 0],
-            name="limandeInnerB_PV",
+            name="limandeInnerB",
             logicalVolume=limandeInnerB_LV,
             motherVolume=limandeB_LV,
             registry=reg
@@ -1063,7 +1063,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         limande1_PV = g4.PhysicalVolume(
             rotation=[0, 0, 0],
             position=[0, -limande_x_or_y, limande_z_pos],
-            name="limande1_PV",
+            name="limande1",
             logicalVolume=limandeA_LV,
             motherVolume=micromegas_assembly,
             registry=reg
@@ -1071,7 +1071,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         limande2_PV = g4.PhysicalVolume(
             rotation=[0, 0, np.pi],
             position=[0, +limande_x_or_y, limande_z_pos],
-            name="limande2_PV",
+            name="limande2",
             logicalVolume=limandeA_LV,
             motherVolume=micromegas_assembly,
             registry=reg
@@ -1079,7 +1079,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         limande3_PV = g4.PhysicalVolume(
             rotation=[0, 0, -np.pi/2],
             position=[+limande_x_or_y, 0, limande_z_pos],
-            name="limande3_PV",
+            name="limande3",
             logicalVolume=limandeB_LV,
             motherVolume=micromegas_assembly,
             registry=reg
@@ -1087,7 +1087,7 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         limande4_PV = g4.PhysicalVolume(
             rotation=[0, 0, +np.pi/2],
             position=[-limande_x_or_y, 0, limande_z_pos],
-            name="limande4_PV",
+            name="limande4",
             logicalVolume=limandeB_LV,
             motherVolume=micromegas_assembly,
             registry=reg

--- a/generator/micromegas.py
+++ b/generator/micromegas.py
@@ -460,7 +460,7 @@ def generate_limandes(name="limande", suffix="", thickness_in_mm=1, thickness_be
 
     return reg
 
-def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_right_side=True):
+def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_right_side=True, simple_geometry=False):
     """
     Generates the micromegas assembly with all its components.
     param name: Name of the assembly volume.
@@ -593,122 +593,123 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         registry=reg
     )
 
-    ### Micromegas to Cap separator (and support)
-    mMTriangularSupportSquare = g4.solid.Box(
-        name="mMTriangularSupportSquare",
-        pX=mMTriangularSupportSquareLength,
-        pY=mMTriangularSupportSquareLength,
-        pZ=mMTriangularSupportThickness,
-        lunit="mm",
-        registry=reg
-    )
-    mMTriangularSupportSquareCut = g4.solid.Box(
-        name="mMTriangularSupportSquareCut",
-        pX=mMTriangularSupportSquareLength*1.414,  # sqrt(2) * length
-        pY=mMTriangularSupportSquareLength*1.414,  # sqrt(2) * length
-        pZ=mMTriangularSupportThickness,
-        lunit="mm",
-        registry=reg
-    )
-    mMTriangularSupport = g4.solid.Subtraction(
-        name="mMTriangularSupport",
-        obj1=mMTriangularSupportSquare,
-        obj2=mMTriangularSupportSquareCut,
-        tra2=[[0, 0, 45*3.1416/180], [mMTriangularSupportSquareLength/2, mMTriangularSupportSquareLength/2, 0]],
-        registry=reg
-    )
+    if not simple_geometry:
+        ### Micromegas to Cap separator (and support)
+        mMTriangularSupportSquare = g4.solid.Box(
+            name="mMTriangularSupportSquare",
+            pX=mMTriangularSupportSquareLength,
+            pY=mMTriangularSupportSquareLength,
+            pZ=mMTriangularSupportThickness,
+            lunit="mm",
+            registry=reg
+        )
+        mMTriangularSupportSquareCut = g4.solid.Box(
+            name="mMTriangularSupportSquareCut",
+            pX=mMTriangularSupportSquareLength*1.414,  # sqrt(2) * length
+            pY=mMTriangularSupportSquareLength*1.414,  # sqrt(2) * length
+            pZ=mMTriangularSupportThickness + 0.001,  # to ensure cut
+            lunit="mm",
+            registry=reg
+        )
+        mMTriangularSupport = g4.solid.Subtraction(
+            name="mMTriangularSupport",
+            obj1=mMTriangularSupportSquare,
+            obj2=mMTriangularSupportSquareCut,
+            tra2=[[0, 0, 45*3.1416/180], [mMTriangularSupportSquareLength/2, mMTriangularSupportSquareLength/2, 0]],
+            registry=reg
+        )
 
-    capSupportBase0 = g4.solid.Box(
-        name="capSupportBase0",
-        pX=capSupportBaseLength,
-        pY=capSupportBaseHeight,
-        pZ=capSupportBaseThickness,
-        lunit="mm",
-        registry=reg
-    )
-    capSupportBaseCut = g4.solid.Box(
-        name="capSupportBaseCut",
-        pX=capSupportBaseCutLength,
-        pY=capSupportBaseCutHeight,
-        pZ=capSupportBaseThickness,
-        lunit="mm",
-        registry=reg
-    )
+        capSupportBase0 = g4.solid.Box(
+            name="capSupportBase0",
+            pX=capSupportBaseLength,
+            pY=capSupportBaseHeight,
+            pZ=capSupportBaseThickness,
+            lunit="mm",
+            registry=reg
+        )
+        capSupportBaseCut = g4.solid.Box(
+            name="capSupportBaseCut",
+            pX=capSupportBaseCutLength,
+            pY=capSupportBaseCutHeight,
+            pZ=capSupportBaseThickness,
+            lunit="mm",
+            registry=reg
+        )
 
-    capSupportBase = g4.solid.Subtraction(
-        name="capSupportBase",
-        obj1=capSupportBase0,
-        obj2=capSupportBaseCut,
-        tra2=[[0, 0, 0], [0, capSupportBaseHeight/2 - capSupportBaseCutHeight/2, 0]],
-        registry=reg
-    )
+        capSupportBase = g4.solid.Subtraction(
+            name="capSupportBase",
+            obj1=capSupportBase0,
+            obj2=capSupportBaseCut,
+            tra2=[[0, 0, 0], [0, capSupportBaseHeight/2 - capSupportBaseCutHeight/2, 0]],
+            registry=reg
+        )
 
-    capSupportColumnA = g4.solid.Box(
-        name="capSupportColumnA",
-        pX=capSupportColumnLengthA,
-        pY=capSupportColumnThicknessA,
-        pZ=capSupportColumnHeightA,
-        lunit="mm",
-        registry=reg
-    )
-    capSupportColumnB = g4.solid.Box(
-        name="capSupportColumnB",
-        pX=capSupportColumnLengthB,
-        pY=capSupportColumnThicknessB,
-        pZ=capSupportColumnHeightB,
-        lunit="mm",
-        registry=reg
-    )
-    capSupportColumnC = g4.solid.Tubs(
-        name="capSupportColumnC",
-        pRMin=0,
-        pRMax=capSupportColumnThicknessC/2,
-        pDz=capSupportColumnHeightC,
-        pSPhi=0,
-        pDPhi=360,
-        aunit="deg",
-        lunit="mm",
-        registry=reg
-    )
+        capSupportColumnA = g4.solid.Box(
+            name="capSupportColumnA",
+            pX=capSupportColumnLengthA,
+            pY=capSupportColumnThicknessA,
+            pZ=capSupportColumnHeightA,
+            lunit="mm",
+            registry=reg
+        )
+        capSupportColumnB = g4.solid.Box(
+            name="capSupportColumnB",
+            pX=capSupportColumnLengthB,
+            pY=capSupportColumnThicknessB,
+            pZ=capSupportColumnHeightB,
+            lunit="mm",
+            registry=reg
+        )
+        capSupportColumnC = g4.solid.Tubs(
+            name="capSupportColumnC",
+            pRMin=0,
+            pRMax=capSupportColumnThicknessC/2,
+            pDz=capSupportColumnHeightC,
+            pSPhi=0,
+            pDPhi=360,
+            aunit="deg",
+            lunit="mm",
+            registry=reg
+        )
 
-    capSupportBaseA = g4.solid.Union(
-        name="capSupportBaseA",
-        obj1=capSupportBase,
-        obj2=capSupportColumnA,
-        tra2=[[0, 0, 0], [0, -capSupportBaseHeight/2 + capSupportColumnThicknessA/2, capSupportBaseThickness/2 +capSupportColumnHeightA/2]],
-        registry=reg
-    )
+        capSupportBaseA = g4.solid.Union(
+            name="capSupportBaseA",
+            obj1=capSupportBase,
+            obj2=capSupportColumnA,
+            tra2=[[0, 0, 0], [0, -capSupportBaseHeight/2 + capSupportColumnThicknessA/2, capSupportBaseThickness/2 +capSupportColumnHeightA/2]],
+            registry=reg
+        )
 
-    capSupportBaseACutted = g4.solid.Subtraction(
-        name="capSupportBaseACutted",
-        obj1=capSupportBaseA,
-        obj2=capSupportColumnB,
-        tra2=[[0, 0, 0], [0, -capSupportBaseHeight/2 + capSupportColumnThicknessB/2 -capSupportColumnProtrusionAtoB, -capSupportBaseThickness/2 + capSupportColumnHeightB/2]],
-        registry=reg
-    )
-    capSupportColumnBC = g4.solid.Union(
-        name="capSupportColumnBC",
-        obj1=capSupportColumnB,
-        obj2=capSupportColumnC,
-        tra2=[[0, 0, 0], [0, 0, capSupportColumnHeightB/2 + capSupportColumnHeightC/2]],
-        registry=reg
-    )
+        capSupportBaseACutted = g4.solid.Subtraction(
+            name="capSupportBaseACutted",
+            obj1=capSupportBaseA,
+            obj2=capSupportColumnB,
+            tra2=[[0, 0, 0], [0, -capSupportBaseHeight/2 + capSupportColumnThicknessB/2 -capSupportColumnProtrusionAtoB, -capSupportBaseThickness/2 + capSupportColumnHeightB/2]],
+            registry=reg
+        )
+        capSupportColumnBC = g4.solid.Union(
+            name="capSupportColumnBC",
+            obj1=capSupportColumnB,
+            obj2=capSupportColumnC,
+            tra2=[[0, 0, 0], [0, 0, capSupportColumnHeightB/2 + capSupportColumnHeightC/2]],
+            registry=reg
+        )
 
-    capSupportBaseColumn = g4.solid.Union(
-        name="capSupportBaseColumn",
-        obj1=capSupportBaseACutted,
-        obj2=capSupportColumnBC,
-        tra2=[[0, 0, 0], [0, -capSupportBaseHeight/2 + capSupportColumnThicknessB/2 - capSupportColumnProtrusionAtoB, capSupportBaseThickness/2 + capSupportColumnHeightB/2 + capSupportColumnBtoBase]],
-        registry=reg
-    )
+        capSupportBaseColumn = g4.solid.Union(
+            name="capSupportBaseColumn",
+            obj1=capSupportBaseACutted,
+            obj2=capSupportColumnBC,
+            tra2=[[0, 0, 0], [0, -capSupportBaseHeight/2 + capSupportColumnThicknessB/2 - capSupportColumnProtrusionAtoB, capSupportBaseThickness/2 + capSupportColumnHeightB/2 + capSupportColumnBtoBase]],
+            registry=reg
+        )
 
-    mMSupport = g4.solid.Union(
-        name="mMSupport",
-        obj1=capSupportBaseColumn,
-        obj2=mMTriangularSupport,
-        tra2=[[0, 0, -135*3.1416/180], [0, - capSupportColumnCtoTriangularSupport - capSupportBaseHeight/2 + capSupportColumnThicknessB/2-capSupportColumnProtrusionAtoB, capSupportBaseThickness/2 + capSupportColumnHeightB + capSupportColumnHeightC + capSupportColumnBtoBase + mMTriangularSupportThickness/2 ]],
-        registry=reg
-    )
+        mMSupport = g4.solid.Union(
+            name="mMSupport",
+            obj1=capSupportBaseColumn,
+            obj2=mMTriangularSupport,
+            tra2=[[0, 0, -135*3.1416/180], [0, - capSupportColumnCtoTriangularSupport - capSupportBaseHeight/2 + capSupportColumnThicknessB/2-capSupportColumnProtrusionAtoB, capSupportBaseThickness/2 + capSupportColumnHeightB + capSupportColumnHeightC + capSupportColumnBtoBase + mMTriangularSupportThickness/2 ]],
+            registry=reg
+        )
 
     ### Roller
     rollerCylinder = g4.solid.Tubs(
@@ -774,12 +775,13 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
     mMBoardCopper = utils.get_solid_by_name("mMBoardCopper", reg)
     mMBoardKapton = utils.get_solid_by_name("mMBoardKapton", reg)
 
-    generate_limandes(name="limande", suffix="Copper", thickness_in_mm=limandeThickness, thickness_below_in_mm=0, is_right_side=is_right_side, registry=reg)
-    generate_limandes(name="limandeInner", suffix="Kapton", thickness_in_mm=limandeThickness - limandeCopperThickness*2, thickness_below_in_mm=limandeCopperThickness, is_right_side=is_right_side, registry=reg)
-    limandeA = utils.get_solid_by_name("limandeA", reg)
-    limandeB = utils.get_solid_by_name("limandeB", reg)
-    limandeInnerA = utils.get_solid_by_name("limandeInnerA", reg)
-    limandeInnerB = utils.get_solid_by_name("limandeInnerB", reg)
+    if not simple_geometry:
+        generate_limandes(name="limande", suffix="Copper", thickness_in_mm=limandeThickness, thickness_below_in_mm=0, is_right_side=is_right_side, registry=reg)
+        generate_limandes(name="limandeInner", suffix="Kapton", thickness_in_mm=limandeThickness - limandeCopperThickness*2, thickness_below_in_mm=limandeCopperThickness, is_right_side=is_right_side, registry=reg)
+        limandeA = utils.get_solid_by_name("limandeA", reg)
+        limandeB = utils.get_solid_by_name("limandeB", reg)
+        limandeInnerA = utils.get_solid_by_name("limandeInnerA", reg)
+        limandeInnerB = utils.get_solid_by_name("limandeInnerB", reg)
 
 
     ### JOIN THE SOLIDS INTO THE ASSEMBLY
@@ -808,12 +810,13 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         name="mMTeflonSpacerPad_LV",
         registry=reg
     )
-    mMSupport_LV = g4.LogicalVolume(
-        solid=mMSupport,
-        material=copper,
-        name="mMSupport_LV",
-        registry=reg
-    )
+    if not simple_geometry:
+        mMSupport_LV = g4.LogicalVolume(
+            solid=mMSupport,
+            material=copper,
+            name="mMSupport_LV",
+            registry=reg
+        )
     roller_LV = g4.LogicalVolume(
         solid=roller,
         material=teflon,
@@ -853,31 +856,32 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         registry=reg
     )
     
-    limandeA_LV = g4.LogicalVolume(
-        solid=limandeA,
-        material=copper,
-        name="limandeA_LV",
-        registry=reg
-    )
-    limandeB_LV = g4.LogicalVolume(
-        solid=limandeB,
-        material=copper,
-        name="limandeB_LV",
-        registry=reg
-    )
-    
-    limandeInnerA_LV = g4.LogicalVolume(
-        solid=limandeInnerA,
-        material=kapton,
-        name="limandeInnerA_LV",
-        registry=reg
-    )
-    limandeInnerB_LV = g4.LogicalVolume(
-        solid=limandeInnerB,
-        material=kapton,
-        name="limandeInnerB_LV",
-        registry=reg
-    )
+    if not simple_geometry:
+        limandeA_LV = g4.LogicalVolume(
+            solid=limandeA,
+            material=copper,
+            name="limandeA_LV",
+            registry=reg
+        )
+        limandeB_LV = g4.LogicalVolume(
+            solid=limandeB,
+            material=copper,
+            name="limandeB_LV",
+            registry=reg
+        )
+        
+        limandeInnerA_LV = g4.LogicalVolume(
+            solid=limandeInnerA,
+            material=kapton,
+            name="limandeInnerA_LV",
+            registry=reg
+        )
+        limandeInnerB_LV = g4.LogicalVolume(
+            solid=limandeInnerB,
+            material=kapton,
+            name="limandeInnerB_LV",
+            registry=reg
+        )
 
 
     # Create the physical volumes and add them to the assembly
@@ -979,27 +983,27 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         registry=reg
     )
 
-
-    ### Micromegas support
-    mMSupportDistanceToCenter_XorY = 220.79/2 #mm
-    mMSupport_pos_z = mMBaseThickness/2 + capSupportBaseThickness/2 + capSupportColumnHeightB + capSupportColumnHeightC + capSupportColumnBtoBase + mMTriangularSupportThickness
-    mMSupport1_PV = g4.PhysicalVolume(
-        rotation=(np.array([0, 0, side_z_dir*45*np.pi/180]) + side_rot).tolist(),  # 45 degrees rotation
-        position=[-side_z_dir*mMSupportDistanceToCenter_XorY, side_z_dir*mMSupportDistanceToCenter_XorY, side_z_dir*mMSupport_pos_z],
-        name="mMSupport1_PV",
-        logicalVolume=mMSupport_LV,
-        motherVolume=micromegas_assembly,
-        registry=reg
-    )
-    mMSupport2_PV = g4.PhysicalVolume(
-        rotation=(np.array([0, 0, -side_z_dir*135*np.pi/180]) + side_rot).tolist(),  # 45 degrees rotation
-        position=[side_z_dir*mMSupportDistanceToCenter_XorY, -side_z_dir*mMSupportDistanceToCenter_XorY, side_z_dir*mMSupport_pos_z],
-        name="mMSupport2_PV",
-        logicalVolume=mMSupport_LV,
-        motherVolume=micromegas_assembly,
-        registry=reg
-    )
-    #print("height of the support: ", mMSupport_pos_z-mMBaseThickness/2+capSupportBaseThickness/2, " mm")
+    if not simple_geometry:
+        ### Micromegas support
+        mMSupportDistanceToCenter_XorY = 220.79/2 #mm
+        mMSupport_pos_z = mMBaseThickness/2 + capSupportBaseThickness/2 + capSupportColumnHeightB + capSupportColumnHeightC + capSupportColumnBtoBase + mMTriangularSupportThickness
+        mMSupport1_PV = g4.PhysicalVolume(
+            rotation=(np.array([0, 0, side_z_dir*45*np.pi/180]) + side_rot).tolist(),  # 45 degrees rotation
+            position=[-side_z_dir*mMSupportDistanceToCenter_XorY, side_z_dir*mMSupportDistanceToCenter_XorY, side_z_dir*mMSupport_pos_z],
+            name="mMSupport1_PV",
+            logicalVolume=mMSupport_LV,
+            motherVolume=micromegas_assembly,
+            registry=reg
+        )
+        mMSupport2_PV = g4.PhysicalVolume(
+            rotation=(np.array([0, 0, -side_z_dir*135*np.pi/180]) + side_rot).tolist(),  # 45 degrees rotation
+            position=[side_z_dir*mMSupportDistanceToCenter_XorY, -side_z_dir*mMSupportDistanceToCenter_XorY, side_z_dir*mMSupport_pos_z],
+            name="mMSupport2_PV",
+            logicalVolume=mMSupport_LV,
+            motherVolume=micromegas_assembly,
+            registry=reg
+        )
+        #print("height of the support: ", mMSupport_pos_z-mMBaseThickness/2+capSupportBaseThickness/2, " mm")
 
     mMCopperFoilLayer2_PV = g4.PhysicalVolume(
         rotation=[0, 0, 0],
@@ -1036,57 +1040,58 @@ def generate_micromegas_assembly(name="micromegas_assembly", registry=None, is_r
         registry=reg
     )
 
-    limandeInnerA_PV = g4.PhysicalVolume(
-        rotation=[0, 0, 0],
-        position=[0, 0, 0],
-        name="limandeInnerA_PV",
-        logicalVolume=limandeInnerA_LV,
-        motherVolume=limandeA_LV,
-        registry=reg
-    )
-    limandeInnerB_PV = g4.PhysicalVolume(
-        rotation=[0, 0, 0],
-        position=[0, 0, 0],
-        name="limandeInnerB_PV",
-        logicalVolume=limandeInnerB_LV,
-        motherVolume=limandeB_LV,
-        registry=reg
-    )
-    
-    limande_z_pos = side_z_dir*(mMBaseThickness/2 + mMBaseBracketThickness + mMTeflonSpacerPadThickness + mMBoardThickness + limandeThickness/2)
-    limande_x_or_y = mMBaseLength/2 - mMBaseEndToBracketDistance - limandeBracketSideWidth/2
-    limande1_PV = g4.PhysicalVolume(
-        rotation=[0, 0, 0],
-        position=[0, -limande_x_or_y, limande_z_pos],
-        name="limande1_PV",
-        logicalVolume=limandeA_LV,
-        motherVolume=micromegas_assembly,
-        registry=reg
-    )
-    limande2_PV = g4.PhysicalVolume(
-        rotation=[0, 0, np.pi],
-        position=[0, +limande_x_or_y, limande_z_pos],
-        name="limande2_PV",
-        logicalVolume=limandeA_LV,
-        motherVolume=micromegas_assembly,
-        registry=reg
-    )
-    limande3_PV = g4.PhysicalVolume(
-        rotation=[0, 0, -np.pi/2],
-        position=[+limande_x_or_y, 0, limande_z_pos],
-        name="limande3_PV",
-        logicalVolume=limandeB_LV,
-        motherVolume=micromegas_assembly,
-        registry=reg
-    )
-    limande4_PV = g4.PhysicalVolume(
-        rotation=[0, 0, +np.pi/2],
-        position=[-limande_x_or_y, 0, limande_z_pos],
-        name="limande4_PV",
-        logicalVolume=limandeB_LV,
-        motherVolume=micromegas_assembly,
-        registry=reg
-    )
+    if not simple_geometry:
+        limandeInnerA_PV = g4.PhysicalVolume(
+            rotation=[0, 0, 0],
+            position=[0, 0, 0],
+            name="limandeInnerA_PV",
+            logicalVolume=limandeInnerA_LV,
+            motherVolume=limandeA_LV,
+            registry=reg
+        )
+        limandeInnerB_PV = g4.PhysicalVolume(
+            rotation=[0, 0, 0],
+            position=[0, 0, 0],
+            name="limandeInnerB_PV",
+            logicalVolume=limandeInnerB_LV,
+            motherVolume=limandeB_LV,
+            registry=reg
+        )
+        
+        limande_z_pos = side_z_dir*(mMBaseThickness/2 + mMBaseBracketThickness + mMTeflonSpacerPadThickness + mMBoardThickness + limandeThickness/2)
+        limande_x_or_y = mMBaseLength/2 - mMBaseEndToBracketDistance - limandeBracketSideWidth/2
+        limande1_PV = g4.PhysicalVolume(
+            rotation=[0, 0, 0],
+            position=[0, -limande_x_or_y, limande_z_pos],
+            name="limande1_PV",
+            logicalVolume=limandeA_LV,
+            motherVolume=micromegas_assembly,
+            registry=reg
+        )
+        limande2_PV = g4.PhysicalVolume(
+            rotation=[0, 0, np.pi],
+            position=[0, +limande_x_or_y, limande_z_pos],
+            name="limande2_PV",
+            logicalVolume=limandeA_LV,
+            motherVolume=micromegas_assembly,
+            registry=reg
+        )
+        limande3_PV = g4.PhysicalVolume(
+            rotation=[0, 0, -np.pi/2],
+            position=[+limande_x_or_y, 0, limande_z_pos],
+            name="limande3_PV",
+            logicalVolume=limandeB_LV,
+            motherVolume=micromegas_assembly,
+            registry=reg
+        )
+        limande4_PV = g4.PhysicalVolume(
+            rotation=[0, 0, +np.pi/2],
+            position=[-limande_x_or_y, 0, limande_z_pos],
+            name="limande4_PV",
+            logicalVolume=limandeB_LV,
+            motherVolume=micromegas_assembly,
+            registry=reg
+        )
 
     return reg
 

--- a/generator/shielding.py
+++ b/generator/shielding.py
@@ -280,13 +280,13 @@ def generate_shielding_volume(name="shielding_LV", open_calibration_lead_block=F
     """
 
     copperCage = g4.solid.Box(
-            "copperCage",
-            copperCageOutSizeX,
-            copperCageOutSizeY,
-            copperCageOutSizeZ,
-            reg,
-            "mm"
-        )
+        name="copperCage",
+        pX=copperCageOutSizeX,
+        pY=copperCageOutSizeY,
+        pZ=copperCageOutSizeZ,
+        registry=reg,
+        lunit="mm"
+    )
 
     calibrationHole = g4.solid.Tubs(
         name="calibrationHole",
@@ -301,13 +301,13 @@ def generate_shielding_volume(name="shielding_LV", open_calibration_lead_block=F
     )
 
     outerGas0 = g4.solid.Box(
-            "outerGas0",
-            outerGasSizeX,
-            outerGasSizeY,
-            outerGasSizeZ,
-            reg,
-            "mm"
-        )
+        name="outerGas0",
+        pX=outerGasSizeX,
+        pY=outerGasSizeY,
+        pZ=outerGasSizeZ,
+        registry=reg,
+        lunit="mm"
+    )
 
     outerGas1 = g4.solid.Union(
         name="outerGas1",
@@ -326,21 +326,21 @@ def generate_shielding_volume(name="shielding_LV", open_calibration_lead_block=F
     )
 
     copperTop = g4.solid.Box(
-        "copperTop",
-        copperTopSizeX,
-        copperTopSizeY,
-        copperTopSizeZ,
-        reg,
-        "mm"
+        name="copperTop",
+        pX=copperTopSizeX,
+        pY=copperTopSizeY,
+        pZ=copperTopSizeZ,
+        registry=reg,
+        lunit="mm"
     )
 
     castleBox = g4.solid.Box(
-        "castleBox0" if open_calibration_lead_block else "castleBox",
-        castleSizeX,
-        castleSizeY,
-        castleSizeZ,
-        reg,
-        "mm"
+        name="castleBox0" if open_calibration_lead_block else "castleBox",
+        pX=castleSizeX,
+        pY=castleSizeY,
+        pZ=castleSizeZ,
+        registry=reg,
+        lunit="mm"
     )
 
     if open_calibration_lead_block:
@@ -368,10 +368,30 @@ def generate_shielding_volume(name="shielding_LV", open_calibration_lead_block=F
             registry=reg
         )
 
-    outerGas_LV = g4.LogicalVolume(outerGas, air, "outerGas_LV", reg)
-    copperCage_LV = g4.LogicalVolume(copperCage, copper, "copperCage_LV", reg)
-    copperTop_LV = g4.LogicalVolume(copperTop, copper, "copperTop_LV", reg)
-    leadShielding_LV = g4.LogicalVolume(castleBox, lead, name, reg)
+    outerGas_LV = g4.LogicalVolume(
+        name="outerGas_LV",
+        solid=outerGas,
+        material=air,
+        registry=reg
+    )
+    copperCage_LV = g4.LogicalVolume(
+        name="copperCage_LV",
+        solid=copperCage,
+        material=copper,
+        registry=reg
+    )
+    copperTop_LV = g4.LogicalVolume(
+        name="copperTop_LV",
+        solid=copperTop,
+        material=copper,
+        registry=reg
+    )
+    leadShielding_LV = g4.LogicalVolume(
+        name=name,
+        solid=castleBox,
+        material=lead,
+        registry=reg
+    )
 
     copperCage_PV = g4.PhysicalVolume(
         rotation=[0,0,0],

--- a/generator/shielding.py
+++ b/generator/shielding.py
@@ -149,7 +149,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", registry=Non
     
     # physical volumes
     leadCage_PV = g4.PhysicalVolume(
-        name="leadCage_PV",
+        name="leadCage",
         rotation=[0, 0, 0],
         position=[0, -castleSizeY/2 + leadSizeY/2, 0],
         logicalVolume=leadCage_LV,
@@ -158,7 +158,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", registry=Non
     )
     
     copperCage_PV = g4.PhysicalVolume(
-        name="copperCage_PV",
+        name="copperCage",
         rotation=[0, 0, 0],
         position=[0, -castleSizeY/2 + leadThickness + copperCageOutSizeY/2, 0],
         logicalVolume=copperCage_LV,
@@ -167,7 +167,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", registry=Non
     )
     
     outerGas_PV = g4.PhysicalVolume(
-        name="outerGas_PV",
+        name="outerGas",
         rotation=[0, 0, 0],
         position=[0, castleSizeY/2 - leadThickness - copperTopThickness - outerGasSizeY/2, 0],
         logicalVolume=outerGas_LV,
@@ -176,7 +176,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", registry=Non
     )
 
     copperTop_PV = g4.PhysicalVolume(
-        name="copperTop_PV",
+        name="copperTop",
         rotation=[0, 0, 0],
         position=[0, -castleSizeY/2 + leadThickness + copperCageOutSizeY + copperTopThickness/2, 0],
         logicalVolume=copperTop_LV,
@@ -185,7 +185,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", registry=Non
     )
     
     leadTop_PV = g4.PhysicalVolume(
-        name="leadTop_PV",
+        name="leadTop",
         rotation=[0, 0, 0],
         position=[0, castleSizeY/2 - leadThickness/2, 0],
         logicalVolume=leadTop_LV,
@@ -262,7 +262,7 @@ def generate_shielding_assembly(name="shielding_assembly", registry=None):
     copperCage_PV = g4.PhysicalVolume(
         rotation=[0,0,0],
         position=[0, copperCageThickness / 2, 0],
-        name="copperCage_PV",
+        name="copperCage",
         logicalVolume=copperCage_LV,
         motherVolume=leadShielding_LV,
         registry=reg
@@ -270,7 +270,7 @@ def generate_shielding_assembly(name="shielding_assembly", registry=None):
     copperTop_PV = g4.PhysicalVolume(
         rotation=[0,0,0],
         position=[0, copperCageOutSizeY / 2 + copperCageThickness / 2 + copperTopThickness / 2, 0],
-        name="copperTop_PV",
+        name="copperTop",
         logicalVolume=copperTop_LV,
         motherVolume=leadShielding_LV,
         registry=reg
@@ -278,7 +278,7 @@ def generate_shielding_assembly(name="shielding_assembly", registry=None):
     outerGas_PV = g4.PhysicalVolume(
         rotation=[0,0,0],
         position=[0, copperCageThickness / 2, 0],
-        name="outerGas_PV",
+        name="outerGas",
         logicalVolume=outerGas_LV,
         motherVolume=copperCage_LV,
         registry=reg
@@ -287,7 +287,7 @@ def generate_shielding_assembly(name="shielding_assembly", registry=None):
     leadShielding_PV = g4.PhysicalVolume(
         rotation=[0,0,0],
         position=[0,0,0],
-        name="leadShielding_PV",
+        name="leadShielding",
         logicalVolume=leadShielding_LV,
         motherVolume=shielding_assembly,
         registry=reg

--- a/generator/shielding.py
+++ b/generator/shielding.py
@@ -356,7 +356,7 @@ def generate_shielding_volume(name="shielding_LV", open_calibration_lead_block=F
             name="castleBox1",
             obj1=castleBox,
             obj2=leadBlock,
-            tra2 =[[0, 0, 0], [castleSizeX/2 - leadBlockLength/2, 0, calibrationHoleZpos]],
+            tra2 =[[0, 0, 0], [castleSizeX/2 - leadBlockLength/2, copperCageThickness, calibrationHoleZpos]],
             registry=reg
         )
 
@@ -364,7 +364,7 @@ def generate_shielding_volume(name="shielding_LV", open_calibration_lead_block=F
             name="castleBox",
             obj1=castleBox1,
             obj2=leadBlock,
-            tra2 =[[0, 0, 0], [castleSizeX/2 - leadBlockLength/2, 0, -calibrationHoleZpos]],
+            tra2 =[[0, 0, 0], [castleSizeX/2 - leadBlockLength/2, copperCageThickness, -calibrationHoleZpos]],
             registry=reg
         )
 

--- a/generator/shielding.py
+++ b/generator/shielding.py
@@ -52,6 +52,9 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", open_calibra
     air = g4.MaterialPredefined("G4_AIR", reg)
     """
 
+    copperCageYpos = -castleSizeY/2 + leadThickness + copperCageOutSizeY/2
+    leadCageYpos = -castleSizeY/2 + leadSizeY/2
+
     leadCage0 = g4.solid.Box(
         name="leadCage0",
         pX=leadSizeX,
@@ -75,7 +78,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", open_calibra
             name="leadCage1",
             obj1=leadCage0,
             obj2=leadBlock,
-            tra2 =[[0, 0, 0], [leadSizeX/2 - leadBlockLength/2, 0, calibrationHoleZpos]],
+            tra2 =[[0, 0, 0], [leadSizeX/2 - leadBlockLength/2, -leadCageYpos, calibrationHoleZpos]],
             registry=reg
         )
 
@@ -83,7 +86,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", open_calibra
             name="leadCage2",
             obj1=leadCage1,
             obj2=leadBlock,
-            tra2 =[[0, 0, 0], [leadSizeX/2 - leadBlockLength/2, 0, -calibrationHoleZpos]],
+            tra2 =[[0, 0, 0], [leadSizeX/2 - leadBlockLength/2, -leadCageYpos, -calibrationHoleZpos]],
             registry=reg
         )
 
@@ -112,7 +115,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", open_calibra
         name="copperCage1",
         obj1=copperCage0,
         obj2=calibrationHole,
-        tra2 =[[0, 90*np.pi/180, 0], [copperCageOutSizeX/2 - copperCageThickness/2, 0, +calibrationHoleZpos]],
+        tra2 =[[0, 90*np.pi/180, 0], [copperCageOutSizeX/2 - copperCageThickness/2, -copperCageYpos, +calibrationHoleZpos]],
         registry=reg
     )
 
@@ -120,7 +123,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", open_calibra
         name="copperCage2",
         obj1=copperCage1,
         obj2=calibrationHole,
-        tra2 =[[0, 90*np.pi/180, 0], [copperCageOutSizeX/2 - copperCageThickness/2, 0, -calibrationHoleZpos]],
+        tra2 =[[0, 90*np.pi/180, 0], [copperCageOutSizeX/2 - copperCageThickness/2, -copperCageYpos, -calibrationHoleZpos]],
         registry=reg
     )
 
@@ -212,7 +215,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", open_calibra
     leadCage_PV = g4.PhysicalVolume(
         name="leadCage",
         rotation=[0, 0, 0],
-        position=[0, -castleSizeY/2 + leadSizeY/2, 0],
+        position=[0, leadCageYpos, 0],
         logicalVolume=leadCage_LV,
         motherVolume=shielding_assembly,
         registry=reg
@@ -221,7 +224,7 @@ def generate_shielding_assembly_by_parts(name="shielding_assembly", open_calibra
     copperCage_PV = g4.PhysicalVolume(
         name="copperCage",
         rotation=[0, 0, 0],
-        position=[0, -castleSizeY/2 + leadThickness + copperCageOutSizeY/2, 0],
+        position=[0, copperCageYpos, 0],
         logicalVolume=copperCage_LV,
         motherVolume=shielding_assembly,
         registry=reg

--- a/generator/trexdm.py
+++ b/generator/trexdm.py
@@ -34,16 +34,37 @@ fieldcage_assembly = utils.get_logical_volume_by_name("fieldcage_assembly", reg)
 outerGas_LV = utils.get_logical_volume_by_name("outerGas_LV", reg)
 innerGas_LV = utils.get_logical_volume_by_name("gas_LV", reg)
 
+gem_position_z = vessel.vesselLength/2 - micromegas.capSupportFinalHeight - micromegas.mMBaseThickness  - micromegas.mMBoardThickness - gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness/2
+
+driftGasGap = (gem_position_z - gem.gemKaptonFoilThickness/2 - gem.gemCopperFoilThickness) - (fieldcage.cathodeKaptonThickness/2 +fieldcage.cathodeCuThickness)
+driftGasSolid = g4.solid.Box(
+    name="driftGasSolid",
+    pX=250,
+    pY=250,
+    pZ=driftGasGap,
+    registry=reg,
+    lunit="mm"
+)
+transferGasSolid = g4.solid.Box(
+    name="transferGasSolid",
+    pX=250,
+    pY=250,
+    pZ=gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness - gem.gemCopperFoilThickness,
+    registry=reg,
+    lunit="mm"
+)
 
 # Create the physical volumes
+
 gemRight_PV = g4.PhysicalVolume(
     name="gemRight_PV",
     logicalVolume=gem_assembly,
     motherVolume=innerGas_LV,
     rotation=[0, 0, 0],
-    position=[0, 0, -(vessel.vesselLength/2 - micromegas.capSupportFinalHeight - micromegas.mMBaseThickness - gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness - micromegas.mMBoardThickness)],
+    position=[0, 0, -(vessel.vesselLength/2 - micromegas.capSupportFinalHeight - micromegas.mMBaseThickness - micromegas.mMBoardThickness - gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness/2)],
     registry=reg
 )
+
 micromegasRight_PV = g4.PhysicalVolume(
     name="micromegasRight_PV",
     logicalVolume=micromegas_assembly,
@@ -52,12 +73,13 @@ micromegasRight_PV = g4.PhysicalVolume(
     position=[0, 0, -(vessel.vesselLength/2 - micromegas.capSupportFinalHeight - 0.5*micromegas.mMBaseThickness)],
     registry=reg
 )
+
 gemLeft_PV = g4.PhysicalVolume(
     name="gemLeft_PV",
     logicalVolume=gem_assembly,
     motherVolume=innerGas_LV,
     rotation=[np.pi, 0, 0],
-    position=[0, 0, vessel.vesselLength/2 - micromegas.capSupportFinalHeight - micromegas.mMBaseThickness - gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness - micromegas.mMBoardThickness],
+    position=[0, 0, vessel.vesselLength/2 - micromegas.capSupportFinalHeight - micromegas.mMBaseThickness - micromegas.mMBoardThickness - gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness/2 ],
     registry=reg
 )
 

--- a/generator/trexdm.py
+++ b/generator/trexdm.py
@@ -93,7 +93,7 @@ sensitiveGasOneSide_LV = g4.LogicalVolume(
 )
 
 sensitiveGasLeft_PV = g4.PhysicalVolume(
-    name="sensitiveGasLeft_PV",
+    name="sensitiveGasLeft",
     logicalVolume=sensitiveGasOneSide_LV,
     motherVolume=innerGas_LV,
     rotation=[0, 0, 0],
@@ -104,7 +104,7 @@ sensitiveGasLeft_PV = g4.PhysicalVolume(
 # Create the physical volumes
 """
 gemRight_PV = g4.PhysicalVolume(
-    name="gemRight_PV",
+    name="gemRight",
     logicalVolume=gem_assembly,
     motherVolume=innerGas_LV,
     rotation=[0, 0, 0],
@@ -113,7 +113,7 @@ gemRight_PV = g4.PhysicalVolume(
 )
 """
 micromegasRight_PV = g4.PhysicalVolume(
-    name="micromegasRight_PV",
+    name="micromegasRight",
     logicalVolume=micromegas_assembly,
     motherVolume=innerGas_LV,
     rotation=[0, 0, 0],
@@ -122,7 +122,7 @@ micromegasRight_PV = g4.PhysicalVolume(
 )
 
 gemLeft_PV = g4.PhysicalVolume(
-    name="gemLeft_PV",
+    name="gemLeft",
     logicalVolume=gem_assembly,
     motherVolume=innerGas_LV,
     rotation=[np.pi, 0, 0],
@@ -131,7 +131,7 @@ gemLeft_PV = g4.PhysicalVolume(
 )
 
 micromegasLeft_PV = g4.PhysicalVolume(
-    name="micromegasLeft_PV",
+    name="micromegasLeft",
     logicalVolume=micromegas_assembly,
     motherVolume=innerGas_LV,
     rotation=[np.pi, 0, 0],
@@ -140,7 +140,7 @@ micromegasLeft_PV = g4.PhysicalVolume(
 )
 
 vesselassembly_PV = g4.PhysicalVolume(
-    name="vesselassembly_PV",
+    name="vesselassembly",
     logicalVolume=vessel_assembly,
     motherVolume=outerGas_LV,
     rotation=[0, 0, 0],
@@ -149,7 +149,7 @@ vesselassembly_PV = g4.PhysicalVolume(
 )
 
 shielding_PV = g4.PhysicalVolume(
-    name="shielding_PV",
+    name="shielding",
     logicalVolume=shielding_assembly,
     motherVolume=world,
     rotation=[0, 0, 0],
@@ -158,7 +158,7 @@ shielding_PV = g4.PhysicalVolume(
 )
 
 fieldcage_PV = g4.PhysicalVolume(
-    name="fieldcage_PV",
+    name="fieldcage",
     logicalVolume=fieldcage_assembly,
     motherVolume=innerGas_LV,
     rotation=[0, 0, 0],

--- a/generator/trexdm.py
+++ b/generator/trexdm.py
@@ -43,6 +43,7 @@ outerGas_LV = utils.get_logical_volume_by_name("outerGas_LV", reg)
 innerGas_LV = utils.get_logical_volume_by_name("gas_LV", reg)
 
 gem_position_z = vessel.vesselLength/2 - micromegas.capSupportFinalHeight - micromegas.mMBaseThickness  - micromegas.mMBoardThickness - gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness/2
+mM_position_z = vessel.vesselLength/2 - micromegas.capSupportFinalHeight - 0.5*micromegas.mMBaseThickness
 
 if CATHODE_TYPE == "plain":
     cathodeLeftSideThickness = fieldcage.cathodeKaptonThickness + fieldcage.cathodeCuThickness*2
@@ -117,7 +118,7 @@ micromegasRight_PV = g4.PhysicalVolume(
     logicalVolume=micromegas_assembly,
     motherVolume=innerGas_LV,
     rotation=[0, 0, 0],
-    position=[0, 0, -(vessel.vesselLength/2 - micromegas.capSupportFinalHeight - 0.5*micromegas.mMBaseThickness)],
+    position=[0, 0, -mM_position_z],
     registry=reg
 )
 
@@ -135,7 +136,7 @@ micromegasLeft_PV = g4.PhysicalVolume(
     logicalVolume=micromegas_assembly,
     motherVolume=innerGas_LV,
     rotation=[np.pi, 0, 0],
-    position=[0, 0, vessel.vesselLength/2 - micromegas.capSupportFinalHeight - 0.5*micromegas.mMBaseThickness],
+    position=[0, 0, mM_position_z],
     registry=reg
 )
 

--- a/generator/trexdm.py
+++ b/generator/trexdm.py
@@ -12,7 +12,7 @@ import utils
 
 reg = g4.Registry()
 
-galactic = g4.MaterialPredefined("G4_Galactic")
+galactic = g4.nist_material_2geant4Material("G4_Galactic")
 # world solid and logical
 ws   = g4.solid.Box("ws",5,5,5,reg, "m")
 world  = g4.LogicalVolume(ws, galactic,"world",reg)

--- a/generator/trexdm.py
+++ b/generator/trexdm.py
@@ -15,7 +15,7 @@ reg = g4.Registry()
 galactic = g4.MaterialPredefined("G4_Galactic")
 # world solid and logical
 ws   = g4.solid.Box("ws",5,5,5,reg, "m")
-wl   = g4.LogicalVolume(ws, galactic,"wl",reg)
+world  = g4.LogicalVolume(ws, galactic,"world",reg)
 
 # Generate the assemblies
 shielding.generate_shielding_assembly_by_parts(registry=reg)
@@ -104,7 +104,7 @@ vesselassembly_PV = g4.PhysicalVolume(
 shielding_PV = g4.PhysicalVolume(
     name="shielding_PV",
     logicalVolume=shielding_assembly,
-    motherVolume=wl,
+    motherVolume=world,
     rotation=[0, 0, 0],
     position=[0, 0, 0],
     registry=reg

--- a/generator/trexdm.py
+++ b/generator/trexdm.py
@@ -19,8 +19,8 @@ world  = g4.LogicalVolume(ws, galactic,"world",reg)
 
 # Generate the assemblies
 shielding.generate_shielding_assembly_by_parts(registry=reg)
-vessel.generate_vessel_assembly(registry=reg)
-micromegas.generate_micromegas_assembly(registry=reg, is_right_side=True)
+vessel.generate_vessel_assembly(registry=reg, left_calibration_is_open=True, right_calibration_is_open=True, gas="Argon1%Isobutane1.1bar")
+micromegas.generate_micromegas_assembly(registry=reg, is_right_side=True, simple_geometry=True)
 gem.generate_gem_assembly(registry=reg, is_right_side=True)
 fieldcage.generate_fieldcage_assembly(registry=reg)
 

--- a/generator/trexdm.py
+++ b/generator/trexdm.py
@@ -13,6 +13,7 @@ import utils
 
 LEFT_CALIBRATION_OPEN = True
 RIGHT_CALIBRATION_OPEN = True
+OPEN_CALIBRATION_LEAD_BLOCKS = False
 GAS = "Neon2%Isobutane1.1bar"
 CATHODE_TYPE = "wired"  # "wired" or "plain"
 SIMPLIFY_MM_GEOMETRY = False
@@ -27,7 +28,7 @@ ws   = g4.solid.Box("ws",5,5,5,reg, "m")
 world  = g4.LogicalVolume(ws, galactic,"world",reg)
 
 # Generate the assemblies
-shielding.generate_shielding_assembly_by_parts(registry=reg)
+shielding.generate_shielding_assembly_by_parts(open_calibration_lead_block=OPEN_CALIBRATION_LEAD_BLOCKS, registry=reg)
 vessel.generate_vessel_assembly(registry=reg, left_calibration_is_open=LEFT_CALIBRATION_OPEN, right_calibration_is_open=RIGHT_CALIBRATION_OPEN, gas=GAS)
 micromegas.generate_micromegas_assembly(registry=reg, is_right_side=True, simple_geometry=SIMPLIFY_MM_GEOMETRY)
 gem.generate_gem_assembly(registry=reg, is_right_side=True)

--- a/generator/trexdm.py
+++ b/generator/trexdm.py
@@ -313,7 +313,16 @@ reg.setWorld(world.name)
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("--childless", action="store_true", default=False)
-defaultName = f"trexdm_{GAS}_cathode-{CATHODE_TYPE}_leftCalib-{'open' if LEFT_CALIBRATION_OPEN else 'closed'}_rightCalib-{'open' if RIGHT_CALIBRATION_OPEN else 'closed'}{'_simplifiedMM' if SIMPLIFY_MM_GEOMETRY else ''}.gdml"
+defaultName = (
+    f"trexdm"
+    f"_{GAS}"
+    f"_cathode-{CATHODE_TYPE}"
+    f"_leftCalib-{'open' if LEFT_CALIBRATION_OPEN else 'closed'}"
+    f"_rightCalib-{'open' if RIGHT_CALIBRATION_OPEN else 'closed'}"
+    f"{'_simplifiedMM' if SIMPLIFY_MM_GEOMETRY else ''}"
+    f"{'_calLeadBlocks-open' if OPEN_CALIBRATION_LEAD_BLOCKS else ''}"
+    f".gdml"
+)
 parser.add_argument("-f", "--file", type=str, default=defaultName, help="Output GDML file name")
 
 args = parser.parse_args()

--- a/generator/trexdm.py
+++ b/generator/trexdm.py
@@ -13,8 +13,11 @@ import utils
 
 LEFT_CALIBRATION_OPEN = True
 RIGHT_CALIBRATION_OPEN = True
+LEFT_GEM = True
+RIGHT_GEM = False
 GAS = "Neon2%Isobutane1.1bar"
 CATHODE_TYPE = "wired"  # "wired" or "plain"
+SIMPLIFY_MM_GEOMETRY = False
 
 
 
@@ -28,8 +31,9 @@ world  = g4.LogicalVolume(ws, galactic,"world",reg)
 # Generate the assemblies
 shielding.generate_shielding_assembly_by_parts(registry=reg)
 vessel.generate_vessel_assembly(registry=reg, left_calibration_is_open=LEFT_CALIBRATION_OPEN, right_calibration_is_open=RIGHT_CALIBRATION_OPEN, gas=GAS)
-micromegas.generate_micromegas_assembly(registry=reg, is_right_side=True, simple_geometry=True)
-gem.generate_gem_assembly(registry=reg, is_right_side=True)
+micromegas.generate_micromegas_assembly(registry=reg, is_right_side=True, simple_geometry=SIMPLIFY_MM_GEOMETRY)
+if LEFT_GEM or RIGHT_GEM:
+    gem.generate_gem_assembly(registry=reg, is_right_side=True)
 fieldcage.generate_fieldcage_assembly(registry=reg, cathode_type=CATHODE_TYPE)
 
 shielding_assembly = utils.get_logical_volume_by_name("shielding_assembly", reg)
@@ -45,74 +49,184 @@ innerGas_LV = utils.get_logical_volume_by_name("gas_LV", reg)
 gem_position_z = vessel.vesselLength/2 - micromegas.capSupportFinalHeight - micromegas.mMBaseThickness  - micromegas.mMBoardThickness - gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness/2
 mM_position_z = vessel.vesselLength/2 - micromegas.capSupportFinalHeight - 0.5*micromegas.mMBaseThickness
 
+# === CREATE THE SENSITIVE GAS VOLUME ===
+sensitiveGasWidth = micromegas.mMLength
 if CATHODE_TYPE == "plain":
-    cathodeLeftSideThickness = fieldcage.cathodeKaptonThickness + fieldcage.cathodeCuThickness*2
+    cathodeSideThickness = fieldcage.cathodeKaptonThickness + fieldcage.cathodeCuThickness*2
 else:  # wired cathode
-    cathodeLeftSideThickness = fieldcage.cathodeWireRadius*2 #fieldcage.cathodeKaptonThickness + fieldcage.cathodeCuThickness*2 + fieldcage.cathodeWireRadius*2
+    cathodeSideThickness = 0 #fieldcage.cathodeWireRadius*2
 
-driftGasGap = (gem_position_z - gem.gemKaptonFoilThickness/2 - gem.gemCopperFoilThickness) - cathodeLeftSideThickness #(fieldcage.cathodeKaptonThickness/2 + fieldcage.cathodeCuThickness)
+driftLeftGasGap = (gem_position_z - gem.gemKaptonFoilThickness/2 - gem.gemCopperFoilThickness) - cathodeSideThickness #(fieldcage.cathodeKaptonThickness/2 + fieldcage.cathodeCuThickness)
 transferGasGap = gem.gemmMSeparatorThickness - gem.gemCopperFoilThickness
-driftGasSolid = g4.solid.Box(
-    name="driftGasSolid",
-    pX=206, # 206 mm because cathode frame is inside active gas volume so I need to avoid that overlap
-    pY=206,
-    pZ=driftGasGap,
+driftLeftGas0 = g4.solid.Box(
+    name="driftLeftGas0",
+    pX=sensitiveGasWidth, # 206 mm because cathode frame is inside active gas volume so I need to avoid that overlap
+    pY=sensitiveGasWidth,
+    pZ=driftLeftGasGap,
     registry=reg,
     lunit="mm"
 )
+cathodeFrameSolid = utils.get_solid_by_name("cathodeFrame", reg)
+sideSeparatorSolid = utils.get_solid_by_name("sideSeparator", reg)
+cathodeFeedThroughSolid = utils.get_solid_by_name("cathodeFeedthrough", reg)
+cathodeWired = utils.get_solid_by_name("cathodeWiredFull", reg)
+driftLeftGas1 = g4.solid.Subtraction(
+    name="driftLeftGas1",
+    obj1=driftLeftGas0,
+    obj2=cathodeFrameSolid,
+    tra2=[[0, 0, 0], [0, 0, -driftLeftGasGap/2]],
+    registry=reg
+)
+driftLeftGas2 = g4.solid.Subtraction(
+    name="driftLeftGas2",
+    obj1=driftLeftGas1,
+    obj2=sideSeparatorSolid,
+    tra2=[[0, 0, 0], [0, 0, -driftLeftGasGap/2]],
+    registry=reg
+)
+
+cathodeFeedThroughPosition = utils.get_position_of_physical_volume("cathodeFeedthrough", reg)
+cathodeFeedThroughPosition[2] -= driftLeftGasGap/2 # relative to driftLeftGas1 center
+cathodeFeedThroughRotation = utils.get_rotation_of_physical_volume("cathodeFeedthrough", reg)
+driftLeftGas3 = g4.solid.Subtraction(
+    name="driftLeftGas3",
+    obj1=driftLeftGas2,
+    obj2=cathodeFeedThroughSolid,
+    tra2=[cathodeFeedThroughRotation, cathodeFeedThroughPosition],
+    registry=reg
+) 
+#rotation=[90*np.pi/180, 0, 0],
+#position=[-cathodeWireLength/2+first_wire_distance_to_frame, 0, cathodeWireRadius],
+cathodeWiredPosition = utils.get_position_of_physical_volume("cathodeWired", reg)
+cathodeWiredPosition[2] -= driftLeftGasGap/2 # relative to driftLeftGas2 center
+cathodeWiredRotation = utils.get_rotation_of_physical_volume("cathodeWired", reg)
+driftLeftGas = g4.solid.Subtraction(
+    name="driftLeftGas",
+    obj1=driftLeftGas3,
+    obj2=cathodeWired,
+    tra2=[cathodeWiredRotation, cathodeWiredPosition],
+    registry=reg
+)
 transferGasSolid = g4.solid.Box(
     name="transferGasSolid",
-    pX=206,
-    pY=206,
+    pX=sensitiveGasWidth,
+    pY=sensitiveGasWidth,
     pZ=transferGasGap,
     registry=reg,
     lunit="mm"
 )
 
-sensitiveGasOneSide = g4.solid.Union(
-    name="sensitiveGasOneSide",
-    obj1=driftGasSolid,
+sensitiveGasLeft = g4.solid.Union(
+    name="sensitiveGasLeft",
+    obj1=driftLeftGas,
     obj2=transferGasSolid,
-    tra2=[[0, 0, 0], [0, 0, driftGasGap/2 + gem.gemCopperFoilThickness*2 + gem.gemKaptonFoilThickness + transferGasGap/2]],
+    tra2=[[0, 0, 0], [0, 0, driftLeftGasGap/2 + gem.gemCopperFoilThickness*2 + gem.gemKaptonFoilThickness + transferGasGap/2]],
     registry=reg
 )
 
+driftRightGasGap = mM_position_z - micromegas.mMBaseThickness/2 - micromegas.mMBoardThickness 
+driftRightGas0 = g4.solid.Box(
+    name="driftRightGas0",
+    pX=sensitiveGasWidth,
+    pY=sensitiveGasWidth,
+    pZ=driftRightGasGap,
+    registry=reg,
+    lunit="mm"
+)
+
+driftRightGas1 = g4.solid.Subtraction(
+    name="driftRightGas1",
+    obj1=driftRightGas0,
+    obj2=cathodeFrameSolid,
+    tra2=[[0, 0, 0], [0, 0, driftRightGasGap/2]],
+    registry=reg
+)
+
+driftRightGas2 = g4.solid.Subtraction(
+    name="driftRightGas2",
+    obj1=driftRightGas1,
+    obj2=sideSeparatorSolid,
+    tra2=[[0, 0, 0], [0, 0, driftRightGasGap/2]],
+    registry=reg
+)
+
+cathodeFeedThroughPosition = utils.get_position_of_physical_volume("cathodeFeedthrough", reg)
+cathodeFeedThroughPosition[2] += driftRightGasGap/2 # relative to driftRightGas1 center
+cathodeFeedThroughRotation = utils.get_rotation_of_physical_volume("cathodeFeedthrough", reg)
+driftRightGas3 = g4.solid.Subtraction(
+    name="driftRightGas3",
+    obj1=driftRightGas2,
+    obj2=cathodeFeedThroughSolid,
+    tra2=[cathodeFeedThroughRotation, cathodeFeedThroughPosition],
+    registry=reg
+)
+
+cathodeWiredPosition = utils.get_position_of_physical_volume("cathodeWired", reg)
+cathodeWiredPosition[2] += driftRightGasGap/2 # relative to driftRightGas2 center
+cathodeWiredRotation = utils.get_rotation_of_physical_volume("cathodeWired", reg)
+driftRightGas = g4.solid.Subtraction(
+    name="driftRightGas",
+    obj1=driftRightGas3,
+    obj2=cathodeWired,
+    tra2=[cathodeWiredRotation, cathodeWiredPosition],
+    registry=reg
+)
+
+sensitiveGasRight = driftRightGas # no transfer gap on right side (no gem)
+
 sensitiveGasBothSides = g4.solid.Union(
     name="sensitiveGasBothSides",
-    obj1=sensitiveGasOneSide,
-    obj2=sensitiveGasOneSide,
-    tra2=[[0, np.pi, 0], [0, 0, -(driftGasGap/2 + cathodeLeftSideThickness)]],
+    obj1=sensitiveGasLeft,
+    obj2=sensitiveGasRight,
+    tra2=[[0, np.pi, 0], [0, 0, -(driftLeftGasGap/2 + cathodeSideThickness)]],
     registry=reg
 )
 
 gas_material = innerGas_LV.material
-sensitiveGasOneSide_LV = g4.LogicalVolume(
-    name="sensitiveGasOneSide_LV",
-    solid=sensitiveGasOneSide,
+sensitiveGasLeft_LV = g4.LogicalVolume(
+    name="sensitiveGasLeft_LV",
+    solid=sensitiveGasLeft,
+    material=gas_material,
+    registry=reg
+)
+
+sensitiveGasRight_LV = g4.LogicalVolume(
+    name="sensitiveGasRight_LV",
+    solid=sensitiveGasRight,
     material=gas_material,
     registry=reg
 )
 
 sensitiveGasLeft_PV = g4.PhysicalVolume(
     name="sensitiveGasLeft",
-    logicalVolume=sensitiveGasOneSide_LV,
+    logicalVolume=sensitiveGasLeft_LV,
     motherVolume=innerGas_LV,
     rotation=[0, 0, 0],
-    position=[0, 0, driftGasGap/2 + cathodeLeftSideThickness],
+    position=[0, 0, driftLeftGasGap/2 + cathodeSideThickness],
+    registry=reg
+)
+
+sensitiveGasRight_PV = g4.PhysicalVolume(
+    name="sensitiveGasRight",
+    logicalVolume=sensitiveGasRight_LV,
+    motherVolume=innerGas_LV,
+    rotation=[0, 0, 0],
+    position=[0, 0, -(driftRightGasGap/2 + cathodeSideThickness)],
     registry=reg
 )
 
 # Create the physical volumes
-"""
-gemRight_PV = g4.PhysicalVolume(
-    name="gemRight",
-    logicalVolume=gem_assembly,
-    motherVolume=innerGas_LV,
-    rotation=[0, 0, 0],
-    position=[0, 0, -(vessel.vesselLength/2 - micromegas.capSupportFinalHeight - micromegas.mMBaseThickness - micromegas.mMBoardThickness - gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness/2)],
-    registry=reg
-)
-"""
+
+if RIGHT_GEM:
+    gemRight_PV = g4.PhysicalVolume(
+        name="gemRight",
+        logicalVolume=gem_assembly,
+        motherVolume=innerGas_LV,
+        rotation=[0, 0, 0],
+        position=[0, 0, -gem_position_z],
+        registry=reg
+    )
+
 micromegasRight_PV = g4.PhysicalVolume(
     name="micromegasRight",
     logicalVolume=micromegas_assembly,
@@ -122,14 +236,15 @@ micromegasRight_PV = g4.PhysicalVolume(
     registry=reg
 )
 
-gemLeft_PV = g4.PhysicalVolume(
-    name="gemLeft",
-    logicalVolume=gem_assembly,
-    motherVolume=innerGas_LV,
-    rotation=[np.pi, 0, 0],
-    position=[0, 0, vessel.vesselLength/2 - micromegas.capSupportFinalHeight - micromegas.mMBaseThickness - micromegas.mMBoardThickness - gem.gemmMSeparatorThickness - gem.gemKaptonFoilThickness/2 ],
-    registry=reg
-)
+if LEFT_GEM:
+    gemLeft_PV = g4.PhysicalVolume(
+        name="gemLeft",
+        logicalVolume=gem_assembly,
+        motherVolume=innerGas_LV,
+        rotation=[np.pi, 0, 0],
+        position=[0, 0, gem_position_z],
+        registry=reg
+    )
 
 micromegasLeft_PV = g4.PhysicalVolume(
     name="micromegasLeft",
@@ -174,7 +289,8 @@ reg.setWorld(world.name)
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("--childless", action="store_true", default=False)
-parser.add_argument("-f", "--file", type=str, default="trexdm.gdml")
+defaultName = f"trexdm_{GAS}_cathode-{CATHODE_TYPE}_GEM-{'left' if LEFT_GEM else ''}{'-right' if RIGHT_GEM else ''}_leftCalib-{'open' if LEFT_CALIBRATION_OPEN else 'closed'}_rightCalib-{'open' if RIGHT_CALIBRATION_OPEN else 'closed'}{'_simplifiedMM' if SIMPLIFY_MM_GEOMETRY else ''}.gdml"
+parser.add_argument("-f", "--file", type=str, default=defaultName, help="Output GDML file name")
 
 args = parser.parse_args()
 

--- a/generator/trexdm_shieldingAsParent.py
+++ b/generator/trexdm_shieldingAsParent.py
@@ -29,13 +29,13 @@ ws   = g4.solid.Box("ws",1.5,1.5,1.5,reg, "m")
 world  = g4.LogicalVolume(ws, air,"world",reg)
 
 # Generate the assemblies
-shielding.generate_shielding_assembly_by_parts(open_calibration_lead_block=OPEN_CALIBRATION_LEAD_BLOCKS, registry=reg)
+shielding.generate_shielding_volume(open_calibration_lead_block=OPEN_CALIBRATION_LEAD_BLOCKS, registry=reg)
 vessel.generate_vessel_assembly(registry=reg, left_calibration_is_open=LEFT_CALIBRATION_OPEN, right_calibration_is_open=RIGHT_CALIBRATION_OPEN, gas=GAS)
 micromegas.generate_micromegas_assembly(registry=reg, is_right_side=True, simple_geometry=SIMPLIFY_MM_GEOMETRY)
 gem.generate_gem_assembly(registry=reg, is_right_side=True)
 fieldcage.generate_fieldcage_assembly(registry=reg, cathode_type=CATHODE_TYPE)
 
-shielding_assembly = utils.get_logical_volume_by_name("shielding_assembly", reg)
+shielding_LV = utils.get_logical_volume_by_name("shielding_LV", reg)
 vessel_assembly = utils.get_logical_volume_by_name("vessel_assembly", reg)
 micromegas_assembly = utils.get_logical_volume_by_name("micromegas_assembly", reg)
 gem_assembly = utils.get_logical_volume_by_name("gem_assembly", reg)
@@ -291,7 +291,7 @@ vesselassembly_PV = g4.PhysicalVolume(
 
 shielding_PV = g4.PhysicalVolume(
     name="shielding",
-    logicalVolume=shielding_assembly,
+    logicalVolume=shielding_LV,
     motherVolume=world,
     rotation=[0, 0, 0],
     position=[0, 0, 0],
@@ -315,7 +315,7 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("--childless", action="store_true", default=False)
 defaultName = (
-    f"trexdm"
+    f"trexdm_shieldingAsParent"
     f"_{GAS}"
     f"_cathode-{CATHODE_TYPE}"
     f"_leftCalib-{'open' if LEFT_CALIBRATION_OPEN else 'closed'}"

--- a/generator/utils.py
+++ b/generator/utils.py
@@ -128,6 +128,22 @@ def get_physical_volume_by_name(name, registry):
     
     return physical_volumes[0]
 
+def get_position_of_physical_volume(name, registry):
+    """
+    Returns the position of the physical volume with the given name from the registry.
+    If the physical volume is not found, it raises a KeyError.
+    """
+    physical_volume = get_physical_volume_by_name(name, registry)
+    return physical_volume.position.eval()
+
+def get_rotation_of_physical_volume(name, registry):
+    """
+    Returns the rotation of the physical volume with the given name from the registry.
+    If the physical volume is not found, it raises a KeyError.
+    """
+    physical_volume = get_physical_volume_by_name(name, registry)
+    return physical_volume.rotation.eval()
+
 def get_material_by_name(name, registry):
     """
     Returns the material with the given name from the registry.

--- a/generator/utils.py
+++ b/generator/utils.py
@@ -66,7 +66,7 @@ def substract_daughters_from_mother(mother, solid_mother=None, rotation_mother=[
                 name=solid_name,
                 obj1=mother_solid,
                 obj2=daughter_solid,
-                tra2=[final_rot, final_pos],
+                tra2=[final_rot, final_pos.tolist()],
                 registry=reg
             )
         except IdenticalNameError:

--- a/generator/utils.py
+++ b/generator/utils.py
@@ -233,7 +233,7 @@ def transfer_childless_world(origin_registry):
     for name, material in origin_registry.materialDict.items():
         #print(f"Transferring material: {name}")
         target_registry.transferMaterial(material)
-    world_volume_target = g4.LogicalVolume(world_volume.solid, world_volume.material,"wl",target_registry)
+    world_volume_target = g4.LogicalVolume(world_volume.solid, world_volume.material, "world", target_registry)
     get_childless_volume(world_volume, world_volume=world_volume_target, is_world_volume=True, registry=target_registry)
     
     for name, solid in origin_registry.solidDict.items():

--- a/generator/utils.py
+++ b/generator/utils.py
@@ -42,11 +42,15 @@ def substract_daughters_from_mother(mother, solid_mother=None, rotation_mother=[
         daughter_logical = daughter.logicalVolume
         solid_name = f"{solid_name_base}-{i}"
         if isinstance(daughter_logical, g4.AssemblyVolume):
-            substract_daughters_from_mother(
+            assembly_pos = daughter.position.eval()
+            assembly_rot = daughter.rotation.eval()
+            rot = tf.matrix2tbxyz( tf.tbxyz2matrix(assembly_rot) @ tf.tbxyz2matrix(rotation_mother) )
+            pos = np.array(position_mother) + tf.tbxyz2matrix(rotation_mother) @ assembly_pos
+            mother_solid = substract_daughters_from_mother(
                                             daughter_logical,
                                             solid_mother=mother_solid,
-                                            rotation_mother=rotation_mother,
-                                            position_mother=position_mother,
+                                            rotation_mother=rot, # assembly_rot, ??
+                                            position_mother=pos, #assembly_pos, ??
                                             base_name=solid_name,
                                             registry=reg
                                         )
@@ -55,14 +59,19 @@ def substract_daughters_from_mother(mother, solid_mother=None, rotation_mother=[
         daughter_rotation = np.array(daughter.rotation.eval())
         daughter_position = np.array(daughter.position.eval())
         final_rot = tf.matrix2tbxyz( tf.tbxyz2matrix(daughter_rotation) @ tf.tbxyz2matrix(rotation_mother) )
-        final_pos = daughter_position + np.array(position_mother)
-        mother_solid = g4.solid.Subtraction(
-            name=solid_name,
-            obj1=mother_solid,
-            obj2=daughter_solid,
-            tra2=[final_rot, final_pos.tolist()],
-            registry=reg
-        )
+        final_pos = np.array(position_mother) + tf.tbxyz2matrix(rotation_mother) @ daughter_position
+        try:
+            print(f"Subtracting {daughter_logical.name} from {mother_solid.name} to create {solid_name}: rot={final_rot}, pos={final_pos}")
+            mother_solid = g4.solid.Subtraction(
+                name=solid_name,
+                obj1=mother_solid,
+                obj2=daughter_solid,
+                tra2=[final_rot, final_pos],
+                registry=reg
+            )
+        except IdenticalNameError:
+            print(f"Solid with name {solid_name} already exists, retrieving it.")
+            mother_solid = get_solid_by_name(solid_name, reg)
     
     #subtracted_solid = g4.LogicalVolume(mother_solid, mother_material, solid_name_base + "_subtracted", reg)
     
@@ -138,22 +147,27 @@ def get_material_by_name(name, registry):
 
 def get_childless_volume(volume, base_name="", position=[0, 0, 0], rotation=[0, 0, 0], world_volume=None, is_world_volume=True, registry=None):
     reg = registry if registry is not None else g4.Registry()
+    print(f"Getting childless volume for: {volume.name}, pos={position}, rot={rotation}, base_name={base_name}")
     mother_logical = volume
     mother_pos = np.array(position) if isinstance(position, (list, tuple)) else position
     mother_rot_matrix = tf.tbxyz2matrix(rotation)
     if volume.daughterVolumes and not is_world_volume and not isinstance(volume, g4.AssemblyVolume):
-        #print(f"Removing children from solid of volume: {volume}")
-        subtracted_solid = substract_daughters_from_mother(volume, reg)
-        try:
-            subtracted_logical = g4.LogicalVolume(
-                name=base_name +volume.name + "_childless_LV",
-                solid=subtracted_solid,
-                material=volume.material,
-                registry=reg
-            )
-        except IdenticalNameError:
-            subtracted_logical = get_logical_volume_by_name(volume.name + "_childless_LV", reg)
-        print(base_name + volume.name + "_childless_PV")
+        print(f"Removing children from solid of volume: {volume}")
+        subtracted_solid = substract_daughters_from_mother(volume,
+                                                           #position_mother=position,
+                                                           #rotation_mother=rotation,
+                                                           registry=reg)
+        #try:
+        print(f"Creating LV: {base_name + volume.name + '_childless_LV'} with solid {subtracted_solid.name}")
+        subtracted_logical = g4.LogicalVolume(
+            name=base_name +volume.name + "_childless_LV",
+            solid=subtracted_solid,
+            material=volume.material,
+            registry=reg
+        )
+        #except IdenticalNameError:
+            #subtracted_logical = get_logical_volume_by_name(volume.name + "_childless_LV", reg)
+        print(f"Creating PV at pos {mother_pos}, rot {tf.matrix2tbxyz(mother_rot_matrix)}")
         g4.PhysicalVolume(
             name=base_name + volume.name + "_childless_PV",
             logicalVolume=subtracted_logical,
@@ -179,19 +193,25 @@ def get_childless_volume(volume, base_name="", position=[0, 0, 0], rotation=[0, 
         rot_matrix= tf.tbxyz2matrix(physical.rotation.eval())
         logical = physical.logicalVolume
         if not logical.daughterVolumes:
-            print(f"{base_name + physical.name}")
+            print(f"Creating PV {base_name + physical.name} at pos {mother_pos + mother_rot_matrix @ pos},  rot  {tf.matrix2tbxyz(mother_rot_matrix @ rot_matrix)}")
             reg.transferLogicalVolume(logical)
             g4.PhysicalVolume(
                 name=base_name + physical.name,
                 logicalVolume=logical,
                 motherVolume=world_volume,
-                position=mother_pos + pos,
-                rotation=tf.matrix2tbxyz(mother_rot_matrix @ rot_matrix),
+                position=mother_pos + mother_rot_matrix @ pos,
+                rotation=tf.matrix2tbxyz(rot_matrix @ mother_rot_matrix),
                 registry=reg
             )
         else:
-            get_childless_volume(logical, base_name=base_name + physical.name + "/", position=mother_pos + pos, rotation=tf.matrix2tbxyz(mother_rot_matrix @ rot_matrix), world_volume=world_volume, is_world_volume=False, registry=reg)
-
+            get_childless_volume(logical,
+                                base_name=base_name + physical.name + "/",
+                                position=mother_pos + mother_rot_matrix @ pos,
+                                rotation=tf.matrix2tbxyz(rot_matrix @ mother_rot_matrix),
+                                world_volume=world_volume,
+                                is_world_volume=False,
+                                registry=reg
+                                )
 
 def transfer_childless_world(origin_registry):
     """
@@ -201,17 +221,26 @@ def transfer_childless_world(origin_registry):
     if not isinstance(origin_registry, g4.Registry):
         raise TypeError("Both origin_registry and target_registry must be instances of g4.Registry")
     world_volume = origin_registry.getWorldVolume()
+    print(f"Transferring world volume: {world_volume.name}")
     if world_volume is None:
         raise ValueError("No world volume found in origin_registry")
 
     target_registry = g4.Registry()
 
     for name, solid in origin_registry.solidDict.items():
+        #print(f"Transferring solid: {name}")
         target_registry.transferSolid(solid)
     for name, material in origin_registry.materialDict.items():
+        #print(f"Transferring material: {name}")
         target_registry.transferMaterial(material)
     world_volume_target = g4.LogicalVolume(world_volume.solid, world_volume.material,"wl",target_registry)
     get_childless_volume(world_volume, world_volume=world_volume_target, is_world_volume=True, registry=target_registry)
+    
+    for name, solid in origin_registry.solidDict.items():
+        if name not in target_registry.solidDict.keys():
+            print(f"Transferring missing solid: {name}")
+            target_registry.transferSolid(solid)
 
+    print(world_volume_target.name)
     target_registry.setWorld(world_volume_target.name)
     return target_registry

--- a/generator/vessel.py
+++ b/generator/vessel.py
@@ -24,7 +24,7 @@ calibrationShieldingCutThickness = 3
 calibrationShieldingCutSeparation = 22
 
 calibrationShieldingOpenShiftY = -9.15 # shift in y direction of the open shielding, to avoid the calibration hole
-calibrationShieldingOpenShiftZ = -15.68 # shift in z direction of the open shielding, to avoid the calibration hole
+calibrationShieldingOpenShiftZ = 15.68 # shift in z direction of the open shielding, to avoid the calibration hole
 
 calibrationExternalTapLength = 10
 calibrationExternalTapRadius = 40
@@ -202,7 +202,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
     shiftZ = 0
     if left_calibration_is_open:
         shiftY = calibrationShieldingOpenShiftY
-        shiftZ = calibrationShieldingOpenShiftZ
+        shiftZ = -calibrationShieldingOpenShiftZ
     vesselSolid_2 = g4.solid.Union(
         name = "vesselSolid_2",
         obj1 = copperVesselSolid_LERE_LIRI,

--- a/generator/vessel.py
+++ b/generator/vessel.py
@@ -33,7 +33,7 @@ calibrationExternalTapPosToVesselDistance = -2
 calibrationInternalTapLength = 5
 calibrationInternalTapRadius = 25
 
-def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibration_is_open=True, right_calibration_is_open=False):
+def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibration_is_open=True, right_calibration_is_open=False, gas="Argon1%Isobutane1.1bar"):
     """
     Generates the vessel geometry for the TREX-DM detector.
     Returns a Geant4 Registry containing the vessel geometry.
@@ -49,7 +49,98 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
     """
     copper = g4.nist_material_2geant4Material("G4_Cu")
     air = g4.nist_material_2geant4Material("G4_AIR")
-    
+
+    argon_element = g4.nist_element_2geant4Element("G4_Ar")
+    argon = g4.MaterialCompound("ArgonGas",
+                                density=1.63897,
+                                state="gas",
+                                #temperature=293.15,
+                                #temperature_unit="K",
+                                #pressure=1,
+                                #pressure_unit="bar",
+                                number_of_components=1,
+                                registry=reg)
+    argon.add_element_massfraction(argon_element, 1)
+    neon_element = g4.nist_element_2geant4Element("G4_Ne")
+    neon = g4.MaterialCompound("NeonGas",
+                                density=0.8282,
+                                state="gas",
+                                #temperature=293.15,
+                                #temperature_unit="K",
+                                #pressure=1,
+                                #pressure_unit="bar",
+                                number_of_components=1,
+                                registry=reg)
+    neon.add_element_massfraction(neon_element, 1)
+
+    hydrogen = g4.nist_material_2geant4Material("G4_H")
+    carbon = g4.nist_material_2geant4Material("G4_C")
+    isobutanegas = g4.MaterialCompound("IsobutaneGas",
+                                       density=2.38467,
+                                       #temperature=293.15,
+                                       #temperature_unit="K",
+                                      #pressure=1,
+                                       #pressure_unit="bar",
+                                       number_of_components=2,
+                                       state="gas",
+                                       registry=reg)
+    isobutanegas.add_material(hydrogen, 0.1734180721461297)
+    isobutanegas.add_material(carbon, 0.8265819278538703)
+    if gas == "Argon1%Isobutane1bar":
+        gas_material = g4.MaterialCompound("Argon1%Isobutane1bar",
+                                           density=1.61882,
+                                           state="gas",
+                                           #temperature=298.15,
+                                           #temperature_unit="K",
+                                           #pressure=1,
+                                           #pressure_unit="bar",
+                                           number_of_components=2,
+                                           registry=reg
+                                           )
+        gas_material.add_material(argon, 0.9855)
+        gas_material.add_material(isobutanegas, 0.0145)
+    elif gas == "Argon1%Isobutane1.1bar":
+        gas_material = g4.MaterialCompound("Argon1%Isobutane1.1bar",
+                                           density=1.78070,
+                                           state="gas",
+                                           #temperature=298.15,
+                                           #temperature_unit="K",
+                                           #pressure=1.1,
+                                           #pressure_unit="bar",
+                                           number_of_components=2,
+                                           registry=reg
+                                           )
+        gas_material.add_material(argon, 0.9855)
+        gas_material.add_material(isobutanegas, 0.0145)
+    elif gas == "Argon2%Isobutane1.1bar":
+        gas_material = g4.MaterialCompound("Argon2%Isobutane1.1bar",
+                                           density=1.78877,
+                                           state="gas",
+                                           #temperature=298.15,
+                                           #temperature_unit="K",
+                                           #pressure=1.1,
+                                           #pressure_unit="bar",
+                                           number_of_components=2,
+                                           registry=reg
+                                           )
+        gas_material.add_material(argon, 0.9711)
+        gas_material.add_material(isobutanegas, 0.0289)
+    elif gas == "Neon2%Isobutane1.1bar":
+        gas_material = g4.MaterialCompound("Neon2%Isobutane1.1bar",
+                                           density=0.91108,
+                                           state="gas",
+                                           #temperature=298.15,
+                                           #temperature_unit="K",
+                                           #pressure=1.1,
+                                           #pressure_unit="bar",
+                                           number_of_components=2,
+                                           registry=reg
+                                           )
+        gas_material.add_material(neon, 0.9445)
+        gas_material.add_material(isobutanegas, 0.0555)
+    else:
+        raise ValueError(f"Gas mixture '{gas}' is not defined.")
+
     copperVesselTubeSolid = g4.solid.Tubs(
         name = "copperVesselTubeSolid",
         pRMin=vesselRadius,
@@ -264,7 +355,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
     gas_LV = g4.LogicalVolume(
         name="gas_LV",
         solid=gasSolid,
-        material=air,
+        material=gas_material,
         registry=reg
     )
         

--- a/generator/vessel.py
+++ b/generator/vessel.py
@@ -360,7 +360,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
     )
         
     vessel_PV = g4.PhysicalVolume(
-        name="vessel_PV",
+        name="vessel",
         logicalVolume=vessel_LV,
         motherVolume=vessel_assembly,
         position=[0, 0, 0],
@@ -368,7 +368,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
         registry=reg
     )
     gas_PV = g4.PhysicalVolume(
-        name="gas_PV",
+        name="gas",
         logicalVolume=gas_LV,
         motherVolume=vessel_assembly,
         position=[0, 0, 0],

--- a/generator/vessel.py
+++ b/generator/vessel.py
@@ -52,7 +52,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
 
     argon_element = g4.nist_element_2geant4Element("G4_Ar")
     argon = g4.MaterialCompound("ArgonGas",
-                                density=1.63897,
+                                density=0.00163897,
                                 state="gas",
                                 #temperature=293.15,
                                 #temperature_unit="K",
@@ -63,7 +63,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
     argon.add_element_massfraction(argon_element, 1)
     neon_element = g4.nist_element_2geant4Element("G4_Ne")
     neon = g4.MaterialCompound("NeonGas",
-                                density=0.8282,
+                                density=0.0008282,
                                 state="gas",
                                 #temperature=293.15,
                                 #temperature_unit="K",
@@ -76,7 +76,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
     hydrogen = g4.nist_material_2geant4Material("G4_H")
     carbon = g4.nist_material_2geant4Material("G4_C")
     isobutanegas = g4.MaterialCompound("IsobutaneGas",
-                                       density=2.38467,
+                                       density=0.00238467,
                                        #temperature=293.15,
                                        #temperature_unit="K",
                                       #pressure=1,
@@ -88,7 +88,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
     isobutanegas.add_material(carbon, 0.8265819278538703)
     if gas == "Argon1%Isobutane1bar":
         gas_material = g4.MaterialCompound("Argon1%Isobutane1bar",
-                                           density=1.61882,
+                                           density=0.00161882,
                                            state="gas",
                                            #temperature=298.15,
                                            #temperature_unit="K",
@@ -101,7 +101,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
         gas_material.add_material(isobutanegas, 0.0145)
     elif gas == "Argon1%Isobutane1.1bar":
         gas_material = g4.MaterialCompound("Argon1%Isobutane1.1bar",
-                                           density=1.78070,
+                                           density=0.00178070,
                                            state="gas",
                                            #temperature=298.15,
                                            #temperature_unit="K",
@@ -114,7 +114,7 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
         gas_material.add_material(isobutanegas, 0.0145)
     elif gas == "Argon2%Isobutane1.1bar":
         gas_material = g4.MaterialCompound("Argon2%Isobutane1.1bar",
-                                           density=1.78877,
+                                           density=0.00178877,
                                            state="gas",
                                            #temperature=298.15,
                                            #temperature_unit="K",
@@ -127,11 +127,37 @@ def generate_vessel_assembly(name="vessel_assembly", registry=None, left_calibra
         gas_material.add_material(isobutanegas, 0.0289)
     elif gas == "Neon2%Isobutane1.1bar":
         gas_material = g4.MaterialCompound("Neon2%Isobutane1.1bar",
-                                           density=0.91108,
+                                           density=0.00091108,
                                            state="gas",
                                            #temperature=298.15,
                                            #temperature_unit="K",
                                            #pressure=1.1,
+                                           #pressure_unit="bar",
+                                           number_of_components=2,
+                                           registry=reg
+                                           )
+        gas_material.add_material(neon, 0.9445)
+        gas_material.add_material(isobutanegas, 0.0555)
+    elif gas == "Neon2%Isobutane2bar":
+        gas_material = g4.MaterialCompound("Neon2%Isobutane2bar",
+                                           density=0.00165651,
+                                           state="gas",
+                                           #temperature=298.15,
+                                           #temperature_unit="K",
+                                           #pressure=2,
+                                           #pressure_unit="bar",
+                                           number_of_components=2,
+                                           registry=reg
+                                           )
+        gas_material.add_material(neon, 0.9445)
+        gas_material.add_material(isobutanegas, 0.0555)
+    elif gas == "Neon2%Isobutane4bar":
+        gas_material = g4.MaterialCompound("Neon2%Isobutane4bar",
+                                           density=0.00331302,
+                                           state="gas",
+                                           #temperature=298.15,
+                                           #temperature_unit="K",
+                                           #pressure=4,
                                            #pressure_unit="bar",
                                            number_of_components=2,
                                            registry=reg


### PR DESCRIPTION
Some information was gather while seeing the inside of the detector on the intervention. This pull requests serves to implement that information.

- [x] Set mM to GEM distance to the measured 6.5mm
- [ ] Add the teflon pieces that are connected to the field cage feedthroughs to protect the HV cables. The ones of the return are cylinders with 15mm outer diameter.
- [ ] Add the copper sheet that guides the mM limandes. It has 1mm thickness.
- [x] Calibration shielding length is indeed 30mm.
- [x] Change to wired cathode
- [ ] Micromegas backplate pilars position
- [ ] Micromegas teflon rollers are present on the 4 sides of the right side mM and 3 sides of the left side mM (the top one is missing).

Other meaningful changes:

- Added some gas mixtures (Ar1Iso at 1bar, Ar1Iso at 1.1bar, Ar2Iso at 1.1bar and Ne2Iso at 1.1bar)
- Add option to simplify micromegas assembly geometry (used to avoid the volumes that are not well substracted from the mother volume when using childless geometry)
- Remove _PV suffix to physical volume names
